### PR TITLE
Fix deck loading by using string identifiers

### DIFF
--- a/WristArcana/Models/DeckRepository.swift
+++ b/WristArcana/Models/DeckRepository.swift
@@ -21,7 +21,7 @@ final class DeckRepository: DeckRepositoryProtocol {
     // MARK: - Private Properties
 
     private var loadedDecks: [TarotDeck] = []
-    private var currentDeckId: UUID?
+    private var currentDeckId: String?
 
     // MARK: - Initialization
 
@@ -70,7 +70,7 @@ final class DeckRepository: DeckRepositoryProtocol {
 
         return decksData.decks.map { deckData in
             TarotDeck(
-                id: UUID(),
+                id: deckData.id,
                 name: deckData.name,
                 cards: deckData.cards
             )

--- a/WristArcana/Models/TarotCard.swift
+++ b/WristArcana/Models/TarotCard.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 struct TarotCard: Codable, Identifiable, Equatable {
-    let id: UUID
+    let id: String
     let name: String
     let imageName: String
     let arcana: ArcanaType
@@ -22,7 +22,7 @@ struct TarotCard: Codable, Identifiable, Equatable {
     }
 
     init(
-        id: UUID = UUID(),
+        id: String = UUID().uuidString,
         name: String,
         imageName: String,
         arcana: ArcanaType,

--- a/WristArcana/Models/TarotDeck.swift
+++ b/WristArcana/Models/TarotDeck.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 struct TarotDeck: Codable, Identifiable, Equatable {
-    let id: UUID
+    let id: String
     let name: String
     let cards: [TarotCard]
 
@@ -16,7 +16,7 @@ struct TarotDeck: Codable, Identifiable, Equatable {
         self.cards.count
     }
 
-    init(id: UUID = UUID(), name: String, cards: [TarotCard]) {
+    init(id: String = UUID().uuidString, name: String, cards: [TarotCard]) {
         self.id = id
         self.name = name
         self.cards = cards
@@ -25,7 +25,7 @@ struct TarotDeck: Codable, Identifiable, Equatable {
     // Static helper for Rider-Waite deck
     static var riderWaite: TarotDeck {
         TarotDeck(
-            id: UUID(),
+            id: UUID().uuidString,
             name: "Rider-Waite",
             cards: []
         )

--- a/WristArcana/ViewModels/DeckSelectionViewModel.swift
+++ b/WristArcana/ViewModels/DeckSelectionViewModel.swift
@@ -12,7 +12,7 @@ final class DeckSelectionViewModel: ObservableObject {
     // MARK: - Published Properties
 
     @Published var availableDecks: [TarotDeck] = []
-    @Published var selectedDeckId: UUID?
+    @Published var selectedDeckId: String?
     @Published var errorMessage: String?
 
     // MARK: - Private Properties
@@ -38,7 +38,7 @@ final class DeckSelectionViewModel: ObservableObject {
         }
     }
 
-    func selectDeck(_ deckId: UUID) {
+    func selectDeck(_ deckId: String) {
         self.selectedDeckId = deckId
         // In future, this would persist selection to UserDefaults or SwiftData
     }

--- a/WristArcana/Views/DeckSelectionView.swift
+++ b/WristArcana/Views/DeckSelectionView.swift
@@ -11,7 +11,7 @@ struct DeckSelectionView: View {
     // MARK: - Properties
 
     let decks: [TarotDeck]
-    @Binding var selectedDeckId: UUID
+    @Binding var selectedDeckId: String
 
     // MARK: - Body
 
@@ -43,7 +43,7 @@ struct DeckSelectionView: View {
                 TarotDeck(name: "Rider-Waite", cards: []),
                 TarotDeck(name: "Marseille", cards: [])
             ],
-            selectedDeckId: .constant(UUID())
+            selectedDeckId: .constant(UUID().uuidString)
         )
     }
 }

--- a/WristArcana/WristArcana Watch AppTests/ModelTests/TarotCardTests.swift
+++ b/WristArcana/WristArcana Watch AppTests/ModelTests/TarotCardTests.swift
@@ -62,7 +62,7 @@ struct TarotCardTests {
 
     @Test func cardEquality() async throws {
         // Given
-        let id = UUID()
+        let id = UUID().uuidString
         let card1 = TarotCard(
             id: id,
             name: "Ace of Cups",

--- a/WristArcana/WristArcana Watch AppTests/ModelTests/TarotDeckTests.swift
+++ b/WristArcana/WristArcana Watch AppTests/ModelTests/TarotDeckTests.swift
@@ -115,7 +115,7 @@ struct TarotDeckTests {
 
     @Test func deckEquality() async throws {
         // Given
-        let id = UUID()
+        let id = UUID().uuidString
         let cards = [
             TarotCard(
                 name: "The Fool",


### PR DESCRIPTION
## Summary
- switch tarot deck and card models to use string identifiers so JSON data decodes correctly
- update repository, view model, and selection view bindings to the new identifier type
- align unit tests with string-based identifiers

## Testing
- not run (not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68ddd545eac0832294be04bae6c43fd9