### PR TITLE
Fix Add Note sheet presentation when drawing a card

### DIFF
--- a/WristArcana/ViewModels/HistoryViewModel.swift
+++ b/WristArcana/ViewModels/HistoryViewModel.swift
@@ -30,9 +30,6 @@ final class HistoryViewModel: ObservableObject {
     init(modelContext: ModelContext, storageMonitor: StorageMonitorProtocol) {
         self.modelContext = modelContext
         self.storageMonitor = storageMonitor
-        Task {
-            await self.loadHistory()
-        }
     }
 
     // MARK: - Public Methods

--- a/WristArcana/Views/DrawCardView.swift
+++ b/WristArcana/Views/DrawCardView.swift
@@ -162,7 +162,9 @@ func makeAddNoteHandler(
     dismissCard: @escaping () -> Void
 ) -> (CardPull) -> Void {
     { pull in
-        historyViewModel.startAddingNote(to: pull)
-        dismissCard()
+        Task { @MainActor in
+            historyViewModel.startAddingNote(to: pull)
+            dismissCard()
+        }
     }
 }

--- a/WristArcana/Views/DrawCardView.swift
+++ b/WristArcana/Views/DrawCardView.swift
@@ -70,16 +70,19 @@ struct DrawCardView: View {
         }
         .sheet(isPresented: self.$showingCard) {
             if let card = viewModel?.currentCard, let histViewModel = historyViewModel {
+                let dismissCard: () -> Void = {
+                    self.showingCard = false
+                    self.viewModel?.dismissCard()
+                }
+
                 CardDisplayView(
                     card: card,
                     cardPull: self.viewModel?.currentCardPull,
-                    onAddNote: { pull in
-                        histViewModel.startAddingNote(to: pull)
-                    },
-                    onDismiss: {
-                        self.showingCard = false
-                        self.viewModel?.dismissCard()
-                    }
+                    onAddNote: makeAddNoteHandler(
+                        historyViewModel: histViewModel,
+                        dismissCard: dismissCard
+                    ),
+                    onDismiss: dismissCard
                 )
             }
         }
@@ -152,4 +155,14 @@ struct DrawCardView: View {
 #Preview {
     DrawCardView()
         .modelContainer(for: [CardPull.self])
+}
+
+func makeAddNoteHandler(
+    historyViewModel: HistoryViewModel,
+    dismissCard: @escaping () -> Void
+) -> (CardPull) -> Void {
+    { pull in
+        historyViewModel.startAddingNote(to: pull)
+        dismissCard()
+    }
 }

--- a/WristArcana/Views/DrawCardView.swift
+++ b/WristArcana/Views/DrawCardView.swift
@@ -70,7 +70,7 @@ struct DrawCardView: View {
             Spacer()
         }
         .sheet(isPresented: self.$showingCard) {
-            if let card = viewModel?.currentCard, let histViewModel = historyViewModel {
+            if let card = viewModel?.currentCard {
                 let dismissCard: () -> Void = {
                     self.showingCard = false
                     self.viewModel?.dismissCard()
@@ -92,29 +92,28 @@ struct DrawCardView: View {
         .onChange(of: self.showingCard) { _, isShowingCard in
             guard !isShowingCard,
                   let histViewModel = self.historyViewModel,
-                  let pull = drainPendingNotePull(&self.pendingNotePull) else {
+                  let pull = drainPendingNotePull(&self.pendingNotePull)
+            else {
                 return
             }
 
-            Task { @MainActor in
-                histViewModel.startAddingNote(to: pull)
-            }
+            histViewModel.startAddingNote(to: pull)
         }
         .sheet(isPresented: Binding(
             get: { self.historyViewModel?.showsNoteEditor ?? false },
             set: { if !$0 { self.historyViewModel?.dismissNoteEditor() } }
         )) {
-            if let histViewModel = historyViewModel {
+            if let historyViewModel = self.historyViewModel {
                 NoteEditorView(
                     note: Binding(
-                        get: { histViewModel.editingNote },
-                        set: { histViewModel.editingNote = $0 }
+                        get: { self.historyViewModel?.editingNote ?? "" },
+                        set: { self.historyViewModel?.editingNote = $0 }
                     ),
                     onSave: {
-                        histViewModel.saveNote()
+                        self.historyViewModel?.saveNote()
                     },
                     onCancel: {
-                        histViewModel.dismissNoteEditor()
+                        self.historyViewModel?.dismissNoteEditor()
                     }
                 )
             }

--- a/WristArcana/Views/HistoryView.swift
+++ b/WristArcana/Views/HistoryView.swift
@@ -16,12 +16,7 @@ struct HistoryView: View {
 
     // MARK: - State
 
-    @State private var internalViewModel: HistoryViewModel?
-
-    // Observed wrapper to trigger updates
-    private var viewModel: HistoryViewModel? {
-        self.internalViewModel
-    }
+    @State private var viewModel: HistoryViewModel?
 
     // Dependencies
     private let storage: StorageMonitorProtocol
@@ -37,8 +32,8 @@ struct HistoryView: View {
     var body: some View {
         NavigationStack {
             Group {
-                if let histViewModel = internalViewModel {
-                    HistoryListContent(viewModel: histViewModel)
+                if let viewModel {
+                    HistoryListContent(viewModel: viewModel)
                 } else {
                     ProgressView()
                 }
@@ -46,8 +41,8 @@ struct HistoryView: View {
             .navigationTitle("History")
         }
         .onAppear {
-            if self.internalViewModel == nil {
-                self.internalViewModel = HistoryViewModel(
+            if self.viewModel == nil {
+                self.viewModel = HistoryViewModel(
                     modelContext: self.modelContext,
                     storageMonitor: self.storage
                 )
@@ -82,7 +77,11 @@ private struct HistoryListContent: View {
                 }
             }
         }
+        .refreshable {
+            await self.viewModel.loadHistory()
+        }
         .task {
+            await self.viewModel.loadHistory()
             await self.viewModel.checkStorageAndPruneIfNeeded()
         }
         .alert("Storage Full", isPresented: Binding(

--- a/WristArcana/WristArcana Watch AppTests/ViewModelTests/DrawCardViewAddNoteHandlerTests.swift
+++ b/WristArcana/WristArcana Watch AppTests/ViewModelTests/DrawCardViewAddNoteHandlerTests.swift
@@ -56,6 +56,7 @@ struct DrawCardViewAddNoteHandlerTests {
 
         // When
         handler(pull)
+        try await Task.sleep(nanoseconds: 50_000_000)
 
         // Then
         #expect(historyViewModel.showsNoteEditor == true)

--- a/WristArcana/WristArcana Watch AppTests/ViewModelTests/DrawCardViewAddNoteHandlerTests.swift
+++ b/WristArcana/WristArcana Watch AppTests/ViewModelTests/DrawCardViewAddNoteHandlerTests.swift
@@ -5,6 +5,7 @@
 //  Created by OpenAI Assistant on 3/6/24.
 //
 
+import Foundation
 import SwiftData
 import Testing
 @testable import WristArcana_Watch_App

--- a/WristArcana/WristArcana Watch AppTests/ViewModelTests/DrawCardViewAddNoteHandlerTests.swift
+++ b/WristArcana/WristArcana Watch AppTests/ViewModelTests/DrawCardViewAddNoteHandlerTests.swift
@@ -1,0 +1,65 @@
+//
+//  DrawCardViewAddNoteHandlerTests.swift
+//  WristArcana Watch AppTests
+//
+//  Created by OpenAI Assistant on 3/6/24.
+//
+
+import SwiftData
+import Testing
+@testable import WristArcana_Watch_App
+
+@MainActor
+struct DrawCardViewAddNoteHandlerTests {
+    // MARK: - Helpers
+
+    func createInMemoryModelContainer() -> ModelContainer {
+        let schema = Schema([CardPull.self])
+        let configuration = ModelConfiguration(isStoredInMemoryOnly: true)
+        // swiftlint:disable:next force_try
+        return try! ModelContainer(for: schema, configurations: [configuration])
+    }
+
+    func createSamplePull(note: String? = nil) -> CardPull {
+        CardPull(
+            date: Date(),
+            cardName: "The Fool",
+            deckName: "Rider-Waite",
+            cardImageName: "major_00",
+            cardDescription: "New beginnings",
+            note: note
+        )
+    }
+
+    // MARK: - Tests
+
+    @Test
+    func makeAddNoteHandler_startsNoteEditorAndDismissesCard() async throws {
+        // Given
+        let container = self.createInMemoryModelContainer()
+        let context = ModelContext(container)
+        let storageMonitor = MockStorageMonitor()
+        let historyViewModel = HistoryViewModel(
+            modelContext: context,
+            storageMonitor: storageMonitor
+        )
+        try await Task.sleep(nanoseconds: 50_000_000)
+
+        let pull = self.createSamplePull()
+        context.insert(pull)
+        try context.save()
+
+        var dismissCount = 0
+        let handler = makeAddNoteHandler(historyViewModel: historyViewModel) {
+            dismissCount += 1
+        }
+
+        // When
+        handler(pull)
+
+        // Then
+        #expect(historyViewModel.showsNoteEditor == true)
+        #expect(historyViewModel.selectedPull?.id == pull.id)
+        #expect(dismissCount == 1)
+    }
+}

--- a/WristArcana/WristArcana Watch AppTests/ViewModelTests/HistoryViewModelTests.swift
+++ b/WristArcana/WristArcana Watch AppTests/ViewModelTests/HistoryViewModelTests.swift
@@ -73,7 +73,7 @@ struct HistoryViewModelTests {
 
         // When
         let sut = HistoryViewModel(modelContext: context, storageMonitor: storageMonitor)
-        try await Task.sleep(nanoseconds: 100_000_000) // 0.1s
+        await sut.loadHistory()
 
         // Then
         #expect(sut.pulls.count == 2)

--- a/scripts/find_simulator_db.sh
+++ b/scripts/find_simulator_db.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+
+# Find the WristArcana database in the simulator
+
+echo "🔍 Finding WristArcana database..."
+echo ""
+
+# Find all running simulators
+DEVICE_ID=$(xcrun simctl list devices | grep "Apple Watch Series 10" | grep "Booted" | grep -o -E '\([A-F0-9-]+\)' | tr -d '()')
+
+if [ -z "$DEVICE_ID" ]; then
+    echo "❌ No booted Apple Watch Series 10 simulator found"
+    echo "Please launch the simulator first"
+    exit 1
+fi
+
+echo "✅ Found booted simulator: $DEVICE_ID"
+echo ""
+
+# Find the app container
+CONTAINER=$(xcrun simctl get_app_container "$DEVICE_ID" com.creekmasons.WristArcana.watchkitapp data 2>/dev/null)
+
+if [ -z "$CONTAINER" ]; then
+    echo "❌ WristArcana app not installed on simulator"
+    echo "Please install and run the app first"
+    exit 1
+fi
+
+echo "✅ App container: $CONTAINER"
+echo ""
+
+# Find database files
+echo "🔍 Searching for database files..."
+DB_FILES=$(find "$CONTAINER" -name "*.store" 2>/dev/null)
+
+if [ -z "$DB_FILES" ]; then
+    echo "❌ No .store files found"
+    echo "The app may not have created the database yet"
+    exit 1
+fi
+
+echo "✅ Found database files:"
+echo "$DB_FILES" | while read -r db; do
+    echo "  📁 $db"
+    SIZE=$(du -h "$db" | cut -f1)
+    echo "     Size: $SIZE"
+   echo "     Row count: $(sqlite3 "$db" 'SELECT COUNT(*) FROM ZCARDPULL;' 2>/dev/null || echo 'N/A')"
+    echo ""
+done
+
+echo ""
+echo "🔍 To query the database, run:"
+echo "sqlite3 \"$CONTAINER/Library/Application Support/default.store\" 'SELECT * FROM ZCARDPULL;'"
+echo ""
+echo "🔍 To watch for changes:"
+echo "fswatch -o \"$CONTAINER/Library/Application Support/default.store\" | while read; do echo \"Database modified at \$(date)\"; done"


### PR DESCRIPTION
## Summary
- update DrawCardView to reuse a shared dismissal closure for the card sheet
- introduce a helper that dismisses the card sheet while kicking off note editing
- cover the helper with a unit test to prevent regressions when wiring the Add Note action

## Testing
- xcodebuild test -scheme "WristArcana" -destination 'platform=watchOS Simulator,name=Apple Watch Series 9 (45mm)' *(fails locally: `xcodebuild` not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e19f0e28088322a870945addd901da