### PR TITLE
Add watch App Shortcut for drawing tarot cards

### DIFF
--- a/WristArcana/Intents/DrawTarotCardIntent.swift
+++ b/WristArcana/Intents/DrawTarotCardIntent.swift
@@ -1,0 +1,97 @@
+//
+//  DrawTarotCardIntent.swift
+//  WristArcana
+//
+//  Created by OpenAI Assistant on 2024-05-23.
+//
+
+import AppIntents
+import SwiftData
+import SwiftUI
+
+@available(watchOS 10.0, *)
+struct DrawTarotCardIntent: AppIntent {
+    static var title: LocalizedStringResource = "Draw Tarot Card"
+    static var description = IntentDescription("Draws a tarot card and saves the reading to your history.")
+    static var openAppWhenRun = false
+    static var parameterSummary: some ParameterSummary {
+        Summary("Draw a tarot card")
+    }
+
+    func perform() async throws -> some IntentResult & ProvidesDialog & ShowsSnippetView {
+        let contextProvider = IntentModelContextProvider()
+        let useCase = DrawCardUseCase(
+            repository: DeckRepository(),
+            storageMonitor: StorageMonitor(),
+            modelContextProvider: contextProvider.makeModelContext
+        )
+
+        let result = try await MainActor.run {
+            try useCase.execute(excluding: [])
+        }
+
+        let dialog = IntentDialog("You drew \(result.card.name) from the \(result.deck.name) deck.")
+        let snippet = DrawTarotCardResultView(result: result)
+        return .result(dialog: dialog, view: snippet)
+    }
+}
+
+@available(watchOS 10.0, *)
+struct DrawTarotShortcuts: AppShortcutsProvider {
+    static var appShortcuts: [AppShortcut] {
+        let shortcut = AppShortcut(
+            intent: DrawTarotCardIntent(),
+            phrases: [
+                AppShortcutInvocationPhrase("Draw a tarot card"),
+                AppShortcutInvocationPhrase("Draw a tarot card in \(.applicationName)"),
+                AppShortcutInvocationPhrase("Pull a tarot card")
+            ],
+            shortTitle: "Draw Card",
+            systemImageName: "sparkles",
+            categories: [.watch]
+        )
+        return [shortcut]
+    }
+}
+
+private struct IntentModelContextProvider {
+    private static var cachedContainer: ModelContainer?
+
+    func makeModelContext() throws -> ModelContext {
+        if let container = Self.cachedContainer {
+            return container.mainContext
+        }
+
+        let container = try ModelContainer(for: CardPull.self)
+        Self.cachedContainer = container
+        return container.mainContext
+    }
+}
+
+private struct DrawTarotCardResultView: View, AppIntentSnippetView {
+    let cardName: String
+    let deckName: String
+    let description: String
+
+    init(result: DrawCardUseCase.Result) {
+        self.cardName = result.card.name
+        self.deckName = result.deck.name
+        self.description = result.card.upright
+    }
+
+    var body: some View {
+        VStack(spacing: 12) {
+            Text(self.cardName)
+                .font(.title)
+                .fontWeight(.semibold)
+            Text("Deck: \(self.deckName)")
+                .font(.headline)
+                .foregroundStyle(.secondary)
+            Text(self.description)
+                .font(.body)
+                .lineLimit(3)
+                .multilineTextAlignment(.center)
+        }
+        .padding()
+    }
+}

--- a/WristArcana/UseCases/DrawCardUseCase.swift
+++ b/WristArcana/UseCases/DrawCardUseCase.swift
@@ -1,0 +1,89 @@
+//
+//  DrawCardUseCase.swift
+//  WristArcana
+//
+//  Created by OpenAI Assistant on 2024-05-23.
+//
+
+import Foundation
+import SwiftData
+
+struct DrawCardUseCase {
+    struct Result {
+        let card: TarotCard
+        let deck: TarotDeck
+        let pull: CardPull
+        let shouldResetSession: Bool
+        let showsStorageWarning: Bool
+    }
+
+    typealias ModelContextProvider = () throws -> ModelContext
+
+    private let repository: DeckRepositoryProtocol
+    private let storageMonitor: StorageMonitorProtocol
+    private let modelContextProvider: ModelContextProvider
+
+    init(
+        repository: DeckRepositoryProtocol,
+        storageMonitor: StorageMonitorProtocol,
+        modelContextProvider: @escaping ModelContextProvider
+    ) {
+        self.repository = repository
+        self.storageMonitor = storageMonitor
+        self.modelContextProvider = modelContextProvider
+    }
+
+    init(
+        repository: DeckRepositoryProtocol,
+        storageMonitor: StorageMonitorProtocol,
+        modelContext: ModelContext
+    ) {
+        self.init(
+            repository: repository,
+            storageMonitor: storageMonitor,
+            modelContextProvider: { modelContext }
+        )
+    }
+
+    @MainActor
+    func execute(excluding excludedCardIDs: Set<UUID>) throws -> Result {
+        let deck = self.repository.getCurrentDeck()
+        let selection = self.selectCard(from: deck, excluding: excludedCardIDs)
+        let context = try self.modelContextProvider()
+
+        let pull = CardPull(
+            date: Date(),
+            cardName: selection.card.name,
+            deckName: deck.name,
+            cardImageName: selection.card.imageName,
+            cardDescription: selection.card.upright
+        )
+
+        context.insert(pull)
+        try context.save()
+
+        return Result(
+            card: selection.card,
+            deck: deck,
+            pull: pull,
+            shouldResetSession: selection.shouldResetSession,
+            showsStorageWarning: self.storageMonitor.isNearCapacity()
+        )
+    }
+
+    private func selectCard(
+        from deck: TarotDeck,
+        excluding excludedCardIDs: Set<UUID>
+    ) -> (card: TarotCard, shouldResetSession: Bool) {
+        let filteredCards = deck.cards.filter { !excludedCardIDs.contains($0.id) }
+        let shouldReset = excludedCardIDs.count >= deck.cards.count || filteredCards.isEmpty
+        let availableCards = shouldReset ? deck.cards : filteredCards
+
+        var generator = SystemRandomNumberGenerator()
+        guard let card = availableCards.randomElement(using: &generator) ?? deck.cards.randomElement(using: &generator) else {
+            preconditionFailure("Deck must contain at least one card")
+        }
+
+        return (card: card, shouldResetSession: shouldReset)
+    }
+}

--- a/WristArcana/Views/DrawCardView.swift
+++ b/WristArcana/Views/DrawCardView.swift
@@ -143,11 +143,12 @@ struct DrawCardView: View {
         .onAppear {
             if self.viewModel == nil {
                 // Create ViewModel with proper environment context
-                self.viewModel = CardDrawViewModel(
+                let useCase = DrawCardUseCase(
                     repository: self.repository,
                     storageMonitor: self.storage,
                     modelContext: self.modelContext
                 )
+                self.viewModel = CardDrawViewModel(drawCardUseCase: useCase)
             }
             if self.historyViewModel == nil {
                 // Create HistoryViewModel for note-taking

--- a/WristArcana/WristArcana Watch AppTests/ViewModelTests/CardDrawViewModelTests.swift
+++ b/WristArcana/WristArcana Watch AppTests/ViewModelTests/CardDrawViewModelTests.swift
@@ -27,11 +27,14 @@ struct CardDrawViewModelTests {
         modelContext: ModelContext? = nil
     ) -> CardDrawViewModel {
         let container = self.createInMemoryModelContainer()
-        return CardDrawViewModel(
+        let context = modelContext ?? ModelContext(container)
+        let useCase = DrawCardUseCase(
             repository: repository ?? MockDeckRepository(),
             storageMonitor: storageMonitor ?? MockStorageMonitor(),
-            modelContext: modelContext ?? ModelContext(container)
+            modelContext: context
         )
+
+        return CardDrawViewModel(drawCardUseCase: useCase, donateShortcut: false)
     }
 
     // MARK: - Initialization Tests

--- a/WristArcana/WristArcana.xcodeproj/project.pbxproj
+++ b/WristArcana/WristArcana.xcodeproj/project.pbxproj
@@ -28,12 +28,15 @@
 		676E56042E8DF4B700F22194 /* CardDisplayView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 676E55FB2E8DF4B700F22194 /* CardDisplayView.swift */; };
 		676E56082E8DF4C700F22194 /* DeckSelectionViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 676E56062E8DF4C700F22194 /* DeckSelectionViewModel.swift */; };
 		676E56092E8DF4C700F22194 /* CardDrawViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 676E56052E8DF4C700F22194 /* CardDrawViewModel.swift */; };
-		676E560A2E8DF4C700F22194 /* HistoryViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 676E56072E8DF4C700F22194 /* HistoryViewModel.swift */; };
-		676E560E2E8DF4D300F22194 /* DeckRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 676E560B2E8DF4D300F22194 /* DeckRepository.swift */; };
-		676E560F2E8DF4D300F22194 /* TarotCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 676E560C2E8DF4D300F22194 /* TarotCard.swift */; };
-		676E56102E8DF4D300F22194 /* TarotDeck.swift in Sources */ = {isa = PBXBuildFile; fileRef = 676E560D2E8DF4D300F22194 /* TarotDeck.swift */; };
-		676E57122E9A4C000F22194 /* CardRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 676E57112E9A4C000F22194 /* CardRepository.swift */; };
-		676E57142E9A4C000F22194 /* CardReferenceViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 676E57132E9A4C000F22194 /* CardReferenceViewModel.swift */; };
+                676E560A2E8DF4C700F22194 /* HistoryViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 676E56072E8DF4C700F22194 /* HistoryViewModel.swift */; };
+                676E560E2E8DF4D300F22194 /* DeckRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 676E560B2E8DF4D300F22194 /* DeckRepository.swift */; };
+                676E560F2E8DF4D300F22194 /* TarotCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 676E560C2E8DF4D300F22194 /* TarotCard.swift */; };
+                676E56102E8DF4D300F22194 /* TarotDeck.swift in Sources */ = {isa = PBXBuildFile; fileRef = 676E560D2E8DF4D300F22194 /* TarotDeck.swift */; };
+                676E57122E9A4C000F22194 /* CardRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 676E57112E9A4C000F22194 /* CardRepository.swift */; };
+                67A000022F00000000F22194 /* DrawCardUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67A000012F00000000F22194 /* DrawCardUseCase.swift */; };
+                67A000042F00000000F22194 /* DrawTarotCardIntent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67A000032F00000000F22194 /* DrawTarotCardIntent.swift */; };
+                67A000082F00000000F22194 /* AppIntents.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 67A000072F00000000F22194 /* AppIntents.framework */; };
+                676E57142E9A4C000F22194 /* CardReferenceViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 676E57132E9A4C000F22194 /* CardReferenceViewModel.swift */; };
 		676E57162E9A4C000F22194 /* FlowLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = 676E57152E9A4C000F22194 /* FlowLayout.swift */; };
 		676E57182E9A4C000F22194 /* CardReferenceView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 676E57172E9A4C000F22194 /* CardReferenceView.swift */; };
 		676E571A2E9A4C000F22194 /* CardListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 676E57192E9A4C000F22194 /* CardListView.swift */; };
@@ -117,8 +120,11 @@
 		676E57192E9A4C000F22194 /* CardListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardListView.swift; sourceTree = "<group>"; };
 		676E571B2E9A4C000F22194 /* CardReferenceDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardReferenceDetailView.swift; sourceTree = "<group>"; };
 		676E571E2E9A4D000F22194 /* NoteInputSanitizer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoteInputSanitizer.swift; sourceTree = "<group>"; };
-		676E571F2E9A4E000F22194 /* NoteEditorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoteEditorView.swift; sourceTree = "<group>"; };
-		676E57202E9A4E000F22194 /* HistoryDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HistoryDetailView.swift; sourceTree = "<group>"; };
+                676E571F2E9A4E000F22194 /* NoteEditorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoteEditorView.swift; sourceTree = "<group>"; };
+                676E57202E9A4E000F22194 /* HistoryDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HistoryDetailView.swift; sourceTree = "<group>"; };
+                67A000012F00000000F22194 /* DrawCardUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DrawCardUseCase.swift; sourceTree = "<group>"; };
+                67A000032F00000000F22194 /* DrawTarotCardIntent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DrawTarotCardIntent.swift; sourceTree = "<group>"; };
+                67A000072F00000000F22194 /* AppIntents.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AppIntents.framework; path = System/Library/Frameworks/AppIntents.framework; sourceTree = SDKROOT; };
 /* End PBXFileReference section */
 
 /* Begin PBXFileSystemSynchronizedRootGroup section */
@@ -140,13 +146,14 @@
 /* End PBXFileSystemSynchronizedRootGroup section */
 
 /* Begin PBXFrameworksBuildPhase section */
-		676E559B2E8DE4F200F22194 /* Frameworks */ = {
-			isa = PBXFrameworksBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
+                676E559B2E8DE4F200F22194 /* Frameworks */ = {
+                        isa = PBXFrameworksBuildPhase;
+                        buildActionMask = 2147483647;
+                        files = (
+                                67A000082F00000000F22194 /* AppIntents.framework in Frameworks */,
+                        );
+                        runOnlyForDeploymentPostprocessing = 0;
+                };
 		676E55AA2E8DE4F400F22194 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
@@ -170,18 +177,21 @@
 				676E55D52E8DE5FF00F22194 /* Configuration */,
 				676E55D42E8DE5F800F22194 /* Resources */,
 				676E55D32E8DE5E600F22194 /* Utilities */,
-				676E55D22E8DE5D300F22194 /* Components */,
-				676E55D12E8DE5CB00F22194 /* Views */,
-				676E55D02E8DE5C200F22194 /* ViewModels */,
-				676E55CE2E8DE5A000F22194 /* Models */,
-				676E55A22E8DE4F200F22194 /* WristArcana Watch App */,
-				676E55B02E8DE4F400F22194 /* WristArcana Watch AppTests */,
-				676E55BA2E8DE4F400F22194 /* WristArcana Watch AppUITests */,
-				676E55992E8DE4F200F22194 /* Products */,
-				676E55A32E8DE4F200F22194 /* WristArcanaApp.swift */,
-			);
-			sourceTree = "<group>";
-		};
+                                676E55D22E8DE5D300F22194 /* Components */,
+                                676E55D12E8DE5CB00F22194 /* Views */,
+                                676E55D02E8DE5C200F22194 /* ViewModels */,
+                                676E55CE2E8DE5A000F22194 /* Models */,
+                                67A000052F00000000F22194 /* UseCases */,
+                                67A000062F00000000F22194 /* Intents */,
+                                676E55A22E8DE4F200F22194 /* WristArcana Watch App */,
+                                676E55B02E8DE4F400F22194 /* WristArcana Watch AppTests */,
+                                676E55BA2E8DE4F400F22194 /* WristArcana Watch AppUITests */,
+                                676E55992E8DE4F200F22194 /* Products */,
+                                676E55A32E8DE4F200F22194 /* WristArcanaApp.swift */,
+                                67A000092F00000000F22194 /* Frameworks */,
+                        );
+                        sourceTree = "<group>";
+                };
 		676E55992E8DE4F200F22194 /* Products */ = {
 			isa = PBXGroup;
 			children = (
@@ -245,17 +255,41 @@
 			path = Components;
 			sourceTree = "<group>";
 		};
-		676E55D32E8DE5E600F22194 /* Utilities */ = {
-			isa = PBXGroup;
-			children = (
-				676E55EF2E8DF49000F22194 /* Extensions */,
-				676E55F02E8DF49000F22194 /* RandomGenerator.swift */,
-				676E55F12E8DF49000F22194 /* StorageMonitor.swift */,
-				676E571E2E9A4D000F22194 /* NoteInputSanitizer.swift */,
-			);
-			path = Utilities;
-			sourceTree = "<group>";
-		};
+                676E55D32E8DE5E600F22194 /* Utilities */ = {
+                        isa = PBXGroup;
+                        children = (
+                                676E55EF2E8DF49000F22194 /* Extensions */,
+                                676E55F02E8DF49000F22194 /* RandomGenerator.swift */,
+                                676E55F12E8DF49000F22194 /* StorageMonitor.swift */,
+                                676E571E2E9A4D000F22194 /* NoteInputSanitizer.swift */,
+                        );
+                        path = Utilities;
+                        sourceTree = "<group>";
+                };
+                67A000052F00000000F22194 /* UseCases */ = {
+                        isa = PBXGroup;
+                        children = (
+                                67A000012F00000000F22194 /* DrawCardUseCase.swift */,
+                        );
+                        path = UseCases;
+                        sourceTree = "<group>";
+                };
+                67A000062F00000000F22194 /* Intents */ = {
+                        isa = PBXGroup;
+                        children = (
+                                67A000032F00000000F22194 /* DrawTarotCardIntent.swift */,
+                        );
+                        path = Intents;
+                        sourceTree = "<group>";
+                };
+                67A000092F00000000F22194 /* Frameworks */ = {
+                        isa = PBXGroup;
+                        children = (
+                                67A000072F00000000F22194 /* AppIntents.framework */,
+                        );
+                        name = Frameworks;
+                        sourceTree = "<group>";
+                };
 		676E55D42E8DE5F800F22194 /* Resources */ = {
 			isa = PBXGroup;
 			children = (
@@ -470,26 +504,28 @@
 				676E56022E8DF4B700F22194 /* DeckSelectionView.swift in Sources */,
 				676E56032E8DF4B700F22194 /* DrawCardView.swift in Sources */,
 				676E56042E8DF4B700F22194 /* CardDisplayView.swift in Sources */,
-				676E55F92E8DF4A800F22194 /* CardImageView.swift in Sources */,
-				676E55FA2E8DF4A800F22194 /* CTAButton.swift in Sources */,
-				676E55F42E8DF49000F22194 /* Date+Formatting.swift in Sources */,
-				676E55EA2E8DF45900F22194 /* Theme.swift in Sources */,
-				676E57122E9A4C000F22194 /* CardRepository.swift in Sources */,
-				676E56082E8DF4C700F22194 /* DeckSelectionViewModel.swift in Sources */,
-				676E56092E8DF4C700F22194 /* CardDrawViewModel.swift in Sources */,
-				676E560A2E8DF4C700F22194 /* HistoryViewModel.swift in Sources */,
-				676E57142E9A4C000F22194 /* CardReferenceViewModel.swift in Sources */,
-				676E55EB2E8DF45900F22194 /* AppConstants.swift in Sources */,
-				676E55D82E8DE7E200F22194 /* CardPull.swift in Sources */,
-				676E55A62E8DE4F200F22194 /* ContentView.swift in Sources */,
-				676E55A42E8DE4F200F22194 /* WristArcanaApp.swift in Sources */,
-				676E560E2E8DF4D300F22194 /* DeckRepository.swift in Sources */,
-				676E560F2E8DF4D300F22194 /* TarotCard.swift in Sources */,
-				676E56102E8DF4D300F22194 /* TarotDeck.swift in Sources */,
-				676E571D2E9A4D000F22194 /* NoteInputSanitizer.swift in Sources */,
-				676E57212E9A4E000F22194 /* NoteEditorView.swift in Sources */,
-				676E57222E9A4E000F22194 /* HistoryDetailView.swift in Sources */,
-			);
+                                676E55F92E8DF4A800F22194 /* CardImageView.swift in Sources */,
+                                676E55FA2E8DF4A800F22194 /* CTAButton.swift in Sources */,
+                                676E55F42E8DF49000F22194 /* Date+Formatting.swift in Sources */,
+                                676E55EA2E8DF45900F22194 /* Theme.swift in Sources */,
+                                676E57122E9A4C000F22194 /* CardRepository.swift in Sources */,
+                                67A000022F00000000F22194 /* DrawCardUseCase.swift in Sources */,
+                                676E56082E8DF4C700F22194 /* DeckSelectionViewModel.swift in Sources */,
+                                676E56092E8DF4C700F22194 /* CardDrawViewModel.swift in Sources */,
+                                676E560A2E8DF4C700F22194 /* HistoryViewModel.swift in Sources */,
+                                676E57142E9A4C000F22194 /* CardReferenceViewModel.swift in Sources */,
+                                676E55EB2E8DF45900F22194 /* AppConstants.swift in Sources */,
+                                676E55D82E8DE7E200F22194 /* CardPull.swift in Sources */,
+                                676E55A62E8DE4F200F22194 /* ContentView.swift in Sources */,
+                                676E55A42E8DE4F200F22194 /* WristArcanaApp.swift in Sources */,
+                                676E560E2E8DF4D300F22194 /* DeckRepository.swift in Sources */,
+                                676E560F2E8DF4D300F22194 /* TarotCard.swift in Sources */,
+                                676E56102E8DF4D300F22194 /* TarotDeck.swift in Sources */,
+                                676E571D2E9A4D000F22194 /* NoteInputSanitizer.swift in Sources */,
+                                676E57212E9A4E000F22194 /* NoteEditorView.swift in Sources */,
+                                676E57222E9A4E000F22194 /* HistoryDetailView.swift in Sources */,
+                                67A000042F00000000F22194 /* DrawTarotCardIntent.swift in Sources */,
+                        );
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 		676E55A92E8DE4F400F22194 /* Sources */ = {


### PR DESCRIPTION
## Summary
- extract a reusable DrawCardUseCase that encapsulates deck selection, history persistence, and storage checks
- wire CardDrawViewModel and DrawCardView through the use case and donate the draw intent after successful pulls
- add a watchOS DrawTarotCardIntent, shortcuts provider, and snippet view while linking AppIntents in the project

## Testing
- Not run (watchOS tests are unavailable in this environment)

------
https://chatgpt.com/codex/tasks/task_e_68e2c3ae1d308322b72cd7fe88a4fbef