### PR TITLE
Add auto sleep manager to allow the watch to rest

### DIFF
--- a/WristArcana/Components/CTAButton.swift
+++ b/WristArcana/Components/CTAButton.swift
@@ -10,6 +10,8 @@ import SwiftUI
 struct CTAButton: View {
     // MARK: - Properties
 
+    @Environment(\.autoSleepManager) private var autoSleepManager
+
     let title: String
     let isLoading: Bool
     let action: () -> Void
@@ -17,7 +19,10 @@ struct CTAButton: View {
     // MARK: - Body
 
     var body: some View {
-        Button(action: self.action) {
+        Button(action: {
+            self.autoSleepManager.registerInteraction()
+            self.action()
+        }) {
             ZStack {
                 Circle()
                     .fill(Theme.Colors.primaryGradient)

--- a/WristArcana/Utilities/AutoSleepManager.swift
+++ b/WristArcana/Utilities/AutoSleepManager.swift
@@ -1,0 +1,111 @@
+import Foundation
+import SwiftUI
+
+protocol AutoSleepManaging {
+    func registerInteraction()
+}
+
+protocol FrontmostTimeoutExtending {
+    @discardableResult
+    func extendFrontmostTimeout(_ timeout: TimeInterval) -> Bool
+}
+
+protocol DateProviding {
+    func now() -> Date
+}
+
+struct SystemDateProvider: DateProviding {
+    func now() -> Date { Date() }
+}
+
+#if os(watchOS)
+import WatchKit
+
+extension WKExtension: FrontmostTimeoutExtending {}
+
+private enum DefaultExtensionProvider {
+    static func make() -> FrontmostTimeoutExtending {
+        WKExtension.shared()
+    }
+}
+#else
+private struct NoopExtensionProvider: FrontmostTimeoutExtending {
+    func extendFrontmostTimeout(_ timeout: TimeInterval) -> Bool { true }
+}
+
+private enum DefaultExtensionProvider {
+    static func make() -> FrontmostTimeoutExtending {
+        NoopExtensionProvider()
+    }
+}
+#endif
+
+final class AutoSleepManager: AutoSleepManaging {
+    private let extensionProvider: FrontmostTimeoutExtending
+    private let timeout: TimeInterval
+    private let throttle: TimeInterval
+    private let dateProvider: DateProviding
+    private var lastExtensionDate: Date?
+
+    init(
+        timeout: TimeInterval = 60,
+        throttle: TimeInterval = 5,
+        extensionProvider: FrontmostTimeoutExtending? = nil,
+        dateProvider: DateProviding = SystemDateProvider()
+    ) {
+        self.timeout = timeout
+        self.throttle = throttle
+        self.extensionProvider = extensionProvider ?? DefaultExtensionProvider.make()
+        self.dateProvider = dateProvider
+    }
+
+    func registerInteraction() {
+        let now = self.dateProvider.now()
+
+        if let last = self.lastExtensionDate,
+           now.timeIntervalSince(last) < self.throttle
+        {
+            return
+        }
+
+        guard self.extensionProvider.extendFrontmostTimeout(self.timeout) else {
+            return
+        }
+
+        self.lastExtensionDate = now
+    }
+}
+
+private struct AutoSleepManagerKey: EnvironmentKey {
+    static let defaultValue: AutoSleepManaging = AutoSleepManager()
+}
+
+extension EnvironmentValues {
+    var autoSleepManager: AutoSleepManaging {
+        get { self[AutoSleepManagerKey.self] }
+        set { self[AutoSleepManagerKey.self] = newValue }
+    }
+}
+
+extension View {
+    func reportUserInteractions(using manager: AutoSleepManaging) -> some View {
+        self.modifier(UserInteractionReporter(autoSleepManager: manager))
+    }
+}
+
+private struct UserInteractionReporter: ViewModifier {
+    let autoSleepManager: AutoSleepManaging
+
+    func body(content: Content) -> some View {
+        content
+            .simultaneousGesture(
+                DragGesture(minimumDistance: 0)
+                    .onChanged { _ in
+                        self.autoSleepManager.registerInteraction()
+                    }
+            )
+            .onTapGesture {
+                self.autoSleepManager.registerInteraction()
+            }
+    }
+}

--- a/WristArcana/Views/CardDisplayView.swift
+++ b/WristArcana/Views/CardDisplayView.swift
@@ -10,6 +10,7 @@ import SwiftUI
 struct CardDisplayView: View {
     // MARK: - Properties
 
+    @Environment(\.autoSleepManager) private var autoSleepManager
     let card: TarotCard
     let cardPull: CardPull?
     let onAddNote: ((CardPull) -> Void)?
@@ -95,6 +96,9 @@ struct CardDisplayView: View {
                     self.onDismiss()
                 }
             }
+        }
+        .onAppear {
+            self.autoSleepManager.registerInteraction()
         }
         .accessibilityElement(children: .contain)
         .accessibilityLabel("Card details for \(self.card.name)")

--- a/WristArcana/Views/ContentView.swift
+++ b/WristArcana/Views/ContentView.swift
@@ -8,8 +8,20 @@
 import SwiftUI
 
 struct ContentView: View {
+    @Environment(\.autoSleepManager) private var autoSleepManager
+    @Environment(\.scenePhase) private var scenePhase
+
     var body: some View {
         MainView()
+            .reportUserInteractions(using: self.autoSleepManager)
+            .onAppear {
+                self.autoSleepManager.registerInteraction()
+            }
+            .onChange(of: self.scenePhase) { _, newPhase in
+                if newPhase == .active {
+                    self.autoSleepManager.registerInteraction()
+                }
+            }
     }
 }
 

--- a/WristArcana/Views/DrawCardView.swift
+++ b/WristArcana/Views/DrawCardView.swift
@@ -12,6 +12,7 @@ struct DrawCardView: View {
     // MARK: - Environment
 
     @Environment(\.modelContext) private var modelContext
+    @Environment(\.autoSleepManager) private var autoSleepManager
 
     // MARK: - State
 
@@ -90,6 +91,10 @@ struct DrawCardView: View {
             }
         }
         .onChange(of: self.showingCard) { _, isShowingCard in
+            if isShowingCard {
+                self.autoSleepManager.registerInteraction()
+            }
+
             guard !isShowingCard,
                   let histViewModel = self.historyViewModel,
                   let pull = drainPendingNotePull(&self.pendingNotePull)
@@ -104,6 +109,8 @@ struct DrawCardView: View {
             set: { if !$0 { self.historyViewModel?.dismissNoteEditor() } }
         )) {
             if let historyViewModel = self.historyViewModel {
+                self.autoSleepManager.registerInteraction()
+
                 NoteEditorView(
                     note: Binding(
                         get: { self.historyViewModel?.editingNote ?? "" },

--- a/WristArcana/Views/HistoryDetailView.swift
+++ b/WristArcana/Views/HistoryDetailView.swift
@@ -10,6 +10,7 @@ import SwiftUI
 struct HistoryDetailView: View {
     // MARK: - Properties
 
+    @Environment(\.autoSleepManager) private var autoSleepManager
     let pull: CardPull
     @ObservedObject var viewModel: HistoryViewModel
     @State private var showDeleteNoteAlert = false
@@ -121,6 +122,9 @@ struct HistoryDetailView: View {
             Button("Cancel", role: .cancel) {}
         } message: {
             Text("Are you sure you want to delete this note? This cannot be undone.")
+        }
+        .onAppear {
+            self.autoSleepManager.registerInteraction()
         }
     }
 }

--- a/WristArcana/Views/HistoryView.swift
+++ b/WristArcana/Views/HistoryView.swift
@@ -13,6 +13,7 @@ struct HistoryView: View {
     // MARK: - Environment
 
     @Environment(\.modelContext) private var modelContext
+    @Environment(\.autoSleepManager) private var autoSleepManager
 
     // MARK: - State
 
@@ -46,6 +47,7 @@ struct HistoryView: View {
                     modelContext: self.modelContext,
                     storageMonitor: self.storage
                 )
+                self.autoSleepManager.registerInteraction()
             }
         }
     }
@@ -54,6 +56,7 @@ struct HistoryView: View {
 // MARK: - Supporting Views
 
 private struct HistoryListContent: View {
+    @Environment(\.autoSleepManager) private var autoSleepManager
     @ObservedObject var viewModel: HistoryViewModel
 
     var body: some View {
@@ -103,6 +106,8 @@ private struct HistoryListContent: View {
             get: { self.viewModel.showsNoteEditor },
             set: { if !$0 { self.viewModel.dismissNoteEditor() } }
         )) {
+            self.autoSleepManager.registerInteraction()
+
             NoteEditorView(
                 note: Binding(
                     get: { self.viewModel.editingNote },

--- a/WristArcana/Views/MainView.swift
+++ b/WristArcana/Views/MainView.swift
@@ -10,6 +10,7 @@ import SwiftUI
 struct MainView: View {
     // MARK: - State
 
+    @Environment(\.autoSleepManager) private var autoSleepManager
     @State private var selectedTab = 1
 
     // MARK: - Body
@@ -35,6 +36,12 @@ struct MainView: View {
                 }
         }
         .tabViewStyle(.page)
+        .onAppear {
+            self.autoSleepManager.registerInteraction()
+        }
+        .onChange(of: self.selectedTab) { _, _ in
+            self.autoSleepManager.registerInteraction()
+        }
     }
 }
 

--- a/WristArcana/Views/NoteEditorView.swift
+++ b/WristArcana/Views/NoteEditorView.swift
@@ -10,6 +10,7 @@ import SwiftUI
 struct NoteEditorView: View {
     // MARK: - Properties
 
+    @Environment(\.autoSleepManager) private var autoSleepManager
     @Binding var note: String
     let onSave: () -> Void
     let onCancel: () -> Void
@@ -68,6 +69,7 @@ struct NoteEditorView: View {
                 }
             }
             .onAppear {
+                self.autoSleepManager.registerInteraction()
                 self.localNote = self.note
             }
         }

--- a/WristArcana/WristArcana Watch AppTests/UtilityTests/AutoSleepManagerTests.swift
+++ b/WristArcana/WristArcana Watch AppTests/UtilityTests/AutoSleepManagerTests.swift
@@ -1,0 +1,70 @@
+import XCTest
+@testable import WristArcana_Watch_App
+
+final class AutoSleepManagerTests: XCTestCase {
+    func testRegisterInteractionThrottlesRepeatedRequests() {
+        let extensionProvider = MockExtensionProvider()
+        let dateProvider = MockDateProvider(current: Date())
+        let manager = AutoSleepManager(
+            timeout: 60,
+            throttle: 10,
+            extensionProvider: extensionProvider,
+            dateProvider: dateProvider
+        )
+
+        manager.registerInteraction()
+        manager.registerInteraction()
+
+        XCTAssertEqual(extensionProvider.recordedTimeouts.count, 1)
+
+        dateProvider.current = dateProvider.current.addingTimeInterval(11)
+        manager.registerInteraction()
+
+        XCTAssertEqual(extensionProvider.recordedTimeouts.count, 2)
+    }
+
+    func testFailedExtensionDoesNotUpdateThrottle() {
+        let extensionProvider = MockExtensionProvider(shouldSucceed: false)
+        let dateProvider = MockDateProvider(current: Date())
+        let manager = AutoSleepManager(
+            timeout: 60,
+            throttle: 10,
+            extensionProvider: extensionProvider,
+            dateProvider: dateProvider
+        )
+
+        manager.registerInteraction()
+        XCTAssertEqual(extensionProvider.recordedTimeouts.count, 1)
+
+        extensionProvider.shouldSucceed = true
+        manager.registerInteraction()
+
+        XCTAssertEqual(extensionProvider.recordedTimeouts.count, 2)
+    }
+}
+
+private final class MockExtensionProvider: FrontmostTimeoutExtending {
+    var recordedTimeouts: [TimeInterval] = []
+    var shouldSucceed: Bool
+
+    init(shouldSucceed: Bool = true) {
+        self.shouldSucceed = shouldSucceed
+    }
+
+    func extendFrontmostTimeout(_ timeout: TimeInterval) -> Bool {
+        self.recordedTimeouts.append(timeout)
+        return self.shouldSucceed
+    }
+}
+
+private final class MockDateProvider: DateProviding {
+    var current: Date
+
+    init(current: Date) {
+        self.current = current
+    }
+
+    func now() -> Date {
+        self.current
+    }
+}

--- a/WristArcana/WristArcanaApp.swift
+++ b/WristArcana/WristArcanaApp.swift
@@ -3,9 +3,12 @@ import SwiftUI
 
 @main
 struct WristArcanaApp: App {
+    private let autoSleepManager = AutoSleepManager()
+
     var body: some Scene {
         WindowGroup {
             ContentView()
+                .environment(\.autoSleepManager, self.autoSleepManager)
         }
         .modelContainer(for: [CardPull.self])
     }


### PR DESCRIPTION
## Summary
- add an AutoSleepManager that throttles frontmost timeout extensions and expose it through the environment
- update core watch views to report user activity to the sleep manager so the display can dim after a reasonable interval
- cover the new manager with unit tests exercising the throttling and retry paths

## Testing
- not run (watchOS build tooling unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68e30b46273083228473249d0c0961e2