### PR TITLE
docs: refresh readme for current app

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,467 +1,85 @@
-# 🔮 Tarot Watch
+# 🔮 Wrist Arcana
 
-> *A beautifully crafted mystical companion for Apple Watch — featuring cryptographically secure card draws, intelligent storage management, and a seamless offline experience.*
+Wrist Arcana is a watchOS 11 companion for personal tarot readings. The app lets you draw a card, jot down quick reflections, and browse the full Rider–Waite–Smith deck – all from your wrist. This repository contains the Xcode project, data set, and scripts that power the current implementation.
 
-[![Swift](https://img.shields.io/badge/Swift-5.9-orange.svg)](https://swift.org)
-[![Platform](https://img.shields.io/badge/watchOS-10.0+-blue.svg)](https://developer.apple.com/watchos/)
-[![License](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE)
-[![CI](https://github.com/Geoffe-Ga/wrist-arcana/workflows/CI/badge.svg)](https://github.com/Geoffe-Ga/wrist-arcana/actions)
-[![codecov](https://codecov.io/gh/Geoffe-Ga/wrist-arcana/branch/main/graph/badge.svg)](https://codecov.io/gh/Geoffe-Ga/wrist-arcana)
+## 📱 App at a glance
 
-[📱 Screenshots](#-screenshots) • [✨ Features](#-features) • [🏗️ Architecture](#️-architecture) • [🚀 Quick Start](#-getting-started) • [📊 Technical Highlights](#-technical-highlights)
+- **Draw a card** – `DrawCardView` drives the primary experience: press the large CTA button to trigger `CardDrawViewModel`, which performs a cryptographically secure draw, plays haptics, and saves the pull to history using SwiftData.【F:WristArcana/Views/DrawCardView.swift†L1-L165】【F:WristArcana/ViewModels/CardDrawViewModel.swift†L1-L128】
+- **Review your readings** – `HistoryView` surfaces the last 100 pulls, supports swipe-to-delete, and opens a detail screen where you can edit or remove notes. Storage pressure is monitored through `StorageMonitor` so the app can prompt for pruning when the watch is close to full.【F:WristArcana/Views/HistoryView.swift†L1-L123】【F:WristArcana/Utilities/StorageMonitor.swift†L1-L66】
+- **Browse the deck** – The reference tab loads every card from `DecksData.json` through `CardRepository`. You can drill from suit lists down to detailed meanings, including upright/reversed interpretations and keyword chips.【F:WristArcana/Views/CardReferenceView.swift†L1-L37】【F:WristArcana/Views/CardReferenceDetailView.swift†L1-L68】【F:WristArcana/Models/CardRepository.swift†L1-L74】
 
----
+## 🧠 Under the hood
 
-## 📱 Screenshots
+### Architecture
 
-<p align="center">
-  <img src="docs/screenshots/draw-screen.png" width="250" alt="Draw Screen">
-  <img src="docs/screenshots/card-display.png" width="250" alt="Card Display">
-  <img src="docs/screenshots/history.png" width="250" alt="History View">
-</p>
+- **SwiftUI + MVVM** – `MainView` hosts a three-tab interface (Reference, Draw, History). Each tab instantiates its own view model, keeping UI code declarative while business logic lives in `ViewModels/` with protocol-driven dependencies.【F:WristArcana/Views/MainView.swift†L1-L36】【F:WristArcana/ViewModels/CardDrawViewModel.swift†L1-L128】
+- **SwiftData persistence** – `CardPull` records are stored locally and exposed to the UI via model containers. History fetches are sorted and truncated in `HistoryViewModel` for fast loading on watch hardware.【F:WristArcana/Models/CardPull.swift†L1-L56】【F:WristArcana/ViewModels/HistoryViewModel.swift†L1-L123】
+- **Protocol-based services** – `DeckRepositoryProtocol`, `StorageMonitorProtocol`, and `CardRepositoryProtocol` allow production implementations to be swapped with mocks in unit tests, keeping view models testable.【F:WristArcana/Models/DeckRepository.swift†L10-L76】【F:WristArcana/Utilities/StorageMonitor.swift†L1-L66】【F:WristArcana/Models/CardRepository.swift†L1-L74】
 
-## ✨ Features
+### Data & assets
 
-### Core Functionality
-- **🎴 Complete Rider-Waite Deck** — All 78 authentic tarot cards with high-quality public domain imagery
-- **🎲 Cryptographic Randomization** — True randomness using `SystemRandomNumberGenerator` with Fisher-Yates shuffle
-- **📖 Persistent History** — Track your spiritual journey with SwiftData-powered local storage
-- **📝 Personal Notes** — Add reflections and insights to any card reading
-  - Voice-to-text, scribble, or keyboard input
-  - 500 character limit with live counter
-  - Sanitized and stored securely on-device
-  - View truncated notes in history list
-  - Tap for full detail view with complete note and card meaning
-- **💾 Smart Storage Management** — Automatic capacity monitoring with intelligent pruning alerts
-- **⚡ Instant Response** — <100ms draw time, <16ms image rendering for buttery-smooth animations
-- **🌙 Offline First** — Zero network dependencies, works anywhere your wrist goes
-- **♿ Accessibility** — Full VoiceOver support with semantic labels
-- **🎨 Dark Mode Native** — Optimized for both light and dark appearances
+- **Deck metadata** – `Resources/DecksData.json` includes every card from the Rider–Waite–Smith deck with upright/reversed text and keyword tags.【F:WristArcana/Resources/DecksData.json†L1-L28】
+- **Card art pipeline** – The `scripts/` directory provides `download_rws_cards.sh` and `process_images.sh` helpers for fetching public-domain artwork and resizing it for the asset catalog (requires ImageMagick).【F:scripts/download_rws_cards.sh†L1-L92】【F:scripts/process_images.sh†L1-L54】
+- **Reusable UI** – Components such as `CTAButton`, `CardImageView`, and `FlowLayout` keep the watch interface consistent across tabs.【F:WristArcana/Components/CTAButton.swift†L1-L82】【F:WristArcana/Components/CardImageView.swift†L1-L78】
 
-### User Experience
-- **Haptic Feedback** — Tactile response on card draw for satisfying interaction
-- **Scrollable Card Details** — Digital Crown scrolling for card names and meanings
-- **Note Taking** — Add personal reflections immediately after drawing or from history
-- **Swipe to Delete** — Intuitive history management
-- **Storage Warnings** — Proactive alerts before capacity issues
+### Quality checks
 
----
+- **Unit tests with Swift Testing** – The `WristArcana Watch AppTests` target exercises repositories, utilities, and view models using Apple’s `Testing` package for async-friendly assertions.【F:WristArcana/WristArcana Watch AppTests/ViewModelTests/CardDrawViewModelTests.swift†L1-L118】
+- **Continuous integration** – `.github/workflows/ci.yml` runs SwiftLint, SwiftFormat, and a watchOS simulator build on macOS runners to guard formatting and compilation.【F:.github/workflows/ci.yml†L1-L36】
 
-## 🏗️ Architecture
+## 🚀 Getting started
 
-### Design Pattern: MVVM + Protocol-Oriented Programming
+1. **Requirements**
+   - Xcode 16.1 (or later) with the watchOS 11 SDK
+   - macOS Sonoma or newer
+   - SwiftLint & SwiftFormat (via Homebrew) if you plan to run the same checks locally
+2. **Clone the repo**
+   ```bash
+   git clone https://github.com/Geoffe-Ga/wrist-arcana.git
+   cd wrist-arcana
+   ```
+3. **Open the project** – Launch `WristArcana/WristArcana.xcodeproj` and select the **WristArcana Watch App** scheme.
+4. **Run on a simulator** – Choose an Apple Watch Series 10 simulator (45mm or 49mm) targeting watchOS 11 and press **⌘R**.
+5. **(Optional) Refresh artwork** – Execute the helper scripts if you need to regenerate card images before importing them into the asset catalog.
 
-```
-┌─────────────────────────────────────────────────────┐
-│                      Views                          │
-│              (SwiftUI Declarative UI)               │
-└─────────────────┬───────────────────────────────────┘
-                  │ @Published / @State
-                  ▼
-┌─────────────────────────────────────────────────────┐
-│                   ViewModels                        │
-│        (Business Logic + State Management)          │
-└─────────────────┬───────────────────────────────────┘
-                  │ Protocol Injection
-                  ▼
-┌─────────────────────────────────────────────────────┐
-│        Models + Repositories + Utilities            │
-│   (Data Layer + Domain Logic + Cross-Cutting)       │
-└─────────────────────────────────────────────────────┘
-                  │
-                  ▼
-┌─────────────────────────────────────────────────────┐
-│            SwiftData + Asset Catalog                │
-│         (Persistence + Local Resources)             │
-└─────────────────────────────────────────────────────┘
-```
+### Running tests
 
-### Technology Stack
-
-| Layer | Technologies |
-|-------|-------------|
-| **UI** | SwiftUI, WatchKit |
-| **Business Logic** | MVVM ViewModels with Combine |
-| **Data Persistence** | SwiftData (iOS 17+) |
-| **Dependency Injection** | Protocol-based with constructor injection |
-| **Testing** | XCTest, XCUITest |
-| **CI/CD** | GitHub Actions, SwiftLint, SwiftFormat |
-| **Code Quality** | 85% test coverage, strict linting rules |
-
-### Key Architectural Decisions
-
-#### 1. **SwiftData Over Core Data**
-- **Why:** Type-safe, Swift-native syntax reduces boilerplate by ~40%
-- **Benefit:** Easier testing with in-memory model containers
-- **Trade-off:** Requires watchOS 10.0+ (acceptable for 2025 target audience)
-
-#### 2. **Local Asset Storage Only**
-- **Why:** Apple Watch apps require offline functionality
-- **Benefit:** Instant image loading (<16ms), zero network overhead
-- **Trade-off:** Larger initial download (~15MB vs potential streaming)
-- **Result:** Better UX, App Store compliance, no server costs
-
-#### 3. **Protocol-Based Dependency Injection**
-- **Why:** Enable 100% unit testable ViewModels
-- **Pattern:**
-  ```swift
-  protocol DeckRepositoryProtocol {
-      func getCurrentDeck() -> TarotDeck
-      func getRandomCard(from: TarotDeck) -> TarotCard
-  }
-  
-  // Production
-  class DeckRepository: DeckRepositoryProtocol { ... }
-  
-  // Testing
-  class MockDeckRepository: DeckRepositoryProtocol { ... }
-  ```
-- **Benefit:** Swap implementations for testing without modifying production code
-
-#### 4. **Cryptographic Randomization**
-- **Why:** Ensure fairness in card selection
-- **Implementation:** `SystemRandomNumberGenerator()` for CSPRNG
-- **Validation:** Statistical tests verify distribution uniformity
-
----
-
-## 📊 Technical Highlights
-
-### Performance Optimizations
-- **Image Loading:** Asset Catalog with automatic resolution selection (@1x/@2x/@3x)
-- **Memory Management:** Aggressive unloading of off-screen card images
-- **Query Efficiency:** SwiftData predicates limit history fetches to 100 most recent
-- **Animation:** 60fps transitions using SwiftUI's built-in GPU acceleration
-
-### Code Quality Metrics
-```
-Test Coverage:      85.3%
-  - Models:         100%
-  - ViewModels:     96.7%
-  - Views:          62.4%
-  - Utilities:      100%
-
-Linting:            0 warnings, 0 errors (SwiftLint strict mode)
-Cyclomatic Complexity: Max 10 per function
-Documentation:      All public APIs documented
-```
-
-### CI/CD Pipeline
-```yaml
-PR Checks:
-  ✓ SwiftLint (strict mode)
-  ✓ SwiftFormat validation
-  ✓ Unit tests (all must pass)
-  ✓ UI tests (critical paths)
-  ✓ Code coverage threshold (≥80%)
-  ✓ Build verification (Release config)
-
-Pre-commit Hooks:
-  ✓ Auto-format code
-  ✓ Run affected tests
-  ✓ Lint staged files
-```
-
----
-
-## 🚀 Getting Started
-
-### Prerequisites
-- **Xcode:** 15.2 or later
-- **macOS:** 14.0+ (Sonoma)
-- **watchOS Target:** 10.0+
-- **Developer Tools:** SwiftLint, SwiftFormat, ImageMagick
-
-### Installation
+Use `xcodebuild` to execute the Swift Testing suites from the command line:
 
 ```bash
-# 1. Clone repository
-git clone https://github.com/Geoffe-Ga/wrist-arcana.git
-cd wrist-arcana
-
-# 2. Install development tools
-brew install swiftlint swiftformat imagemagick pre-commit
-
-# 3. Set up pre-commit hooks
-pre-commit install
-
-# 4. Download and process card images (required first-time setup)
-chmod +x scripts/download_rws_cards.sh scripts/process_images.sh
-./scripts/download_rws_cards.sh      # ~5 minutes
-./scripts/process_images.sh          # ~2 minutes
-
-# 5. Open project
-open WristArcana.xcodeproj
-
-# 6. Select "Apple Watch Series 9 (45mm)" simulator
-# 7. Build and Run (⌘R)
-```
-
-### Running Tests
-
-```bash
-# Run all tests with coverage
 xcodebuild test \
-  -scheme WristArcana \
-  -destination 'platform=watchOS Simulator,name=Apple Watch Series 9 (45mm)' \
-  -enableCodeCoverage YES
-
-# View coverage report
-xcodebuild test \
-  -scheme WristArcana \
-  -destination 'platform=watchOS Simulator,name=Apple Watch Series 9 (45mm)' \
-  -enableCodeCoverage YES \
-  -resultBundlePath TestResults.xcresult
-
-open TestResults.xcresult
+  -project WristArcana/WristArcana.xcodeproj \
+  -scheme "WristArcana Watch App" \
+  -destination 'platform=watchOS Simulator,name=Apple Watch Series 10 (46mm)'
 ```
 
-### Quick Test in Xcode
-```bash
-# Unit tests only (fast)
-⌘U
+### Handy scripts
 
-# Specific test class
-⌘U with CardDrawViewModelTests.swift selected
-```
+- `scripts/download_rws_cards.sh` – Downloads the Rider–Waite–Smith scans from sacred-texts.com (public domain).
+- `scripts/process_images.sh` – Resizes and centers each card into @1x/@2x/@3x PNGs for the watch asset catalog.
+- `scripts/find_simulator_db.sh` – Locates the SwiftData store inside a running watch simulator for debugging saved pulls.【F:scripts/find_simulator_db.sh†L1-L55】
 
----
-
-## 📁 Project Structure
+## 📁 Repository layout
 
 ```
 WristArcana/
-├── WristArcana/
-│   ├── WristArcanaApp.swift          # App entry point
-│   ├── Models/                       # Data models (100% coverage)
-│   │   ├── TarotCard.swift
-│   │   ├── TarotDeck.swift
-│   │   ├── CardPull.swift
-│   │   └── DeckRepository.swift
-│   ├── ViewModels/                   # Business logic (96% coverage)
-│   │   ├── CardDrawViewModel.swift
-│   │   ├── DeckSelectionViewModel.swift
-│   │   └── HistoryViewModel.swift
-│   ├── Views/                        # SwiftUI interfaces
-│   │   ├── MainView.swift
-│   │   ├── DrawCardView.swift
-│   │   ├── CardDisplayView.swift
-│   │   └── HistoryView.swift
-│   ├── Components/                   # Reusable UI components
-│   │   ├── CardImageView.swift
-│   │   ├── CTAButton.swift
-│   │   └── HistoryRow.swift
-│   ├── Utilities/                    # Helpers (100% coverage)
-│   │   ├── RandomGenerator.swift
-│   │   ├── StorageMonitor.swift
-│   │   └── Extensions/
-│   ├── Resources/
-│   │   ├── Assets.xcassets/         # 78 card images + app icon
-│   │   └── DecksData.json           # Card metadata
-│   └── Configuration/
-│       ├── AppConstants.swift
-│       └── Theme.swift
-├── WristArcanaTests/                  # Unit tests
-├── WristArcanaUITests/                # UI automation tests
-├── scripts/                          # Development automation
-│   ├── download_rws_cards.sh
-│   ├── process_images.sh
-│   └── verify_assets.sh
-└── docs/                             # Documentation + screenshots
+├── Components/              # Reusable SwiftUI building blocks
+├── Configuration/           # Theme and constants
+├── Models/                  # TarotCard, TarotDeck, CardPull, repositories
+├── Resources/               # DecksData.json + Assets.xcassets
+├── Utilities/               # Storage monitor, random generator, note sanitizer
+├── ViewModels/              # MVVM logic for each tab
+├── Views/                   # SwiftUI screens (Main, Draw, Reference, History)
+├── WristArcana Watch AppTests/   # Swift Testing suites + mocks
+├── WristArcana Watch AppUITests/ # UI test target scaffold
+└── WristArcana.xcodeproj
 ```
 
----
+## 📜 License & attribution
 
-## 🧪 Testing Strategy
-
-### Test-Driven Development (TDD)
-This project follows strict TDD methodology:
-1. **Red:** Write failing test
-2. **Green:** Implement minimum code to pass
-3. **Refactor:** Clean up while maintaining passing tests
-
-### Example Test Coverage
-
-```swift
-// CardDrawViewModelTests.swift
-class CardDrawViewModelTests: XCTestCase {
-    func test_drawCard_returnsRandomCard() async throws { }
-    func test_drawCard_savesToHistory() async throws { }
-    func test_drawCard_usesCryptographicRandomization() async throws { }
-    func test_drawCard_whenStorageFull_showsWarning() async throws { }
-    func test_drawCard_providesHapticFeedback() { }
-    // ... 15+ tests covering all paths
-}
-```
-
-### UI Test Example
-
-```swift
-func test_drawCard_displaysCardSuccessfully() {
-    app.buttons["DRAW"].tap()
-    
-    let cardImage = app.images.firstMatch
-    XCTAssertTrue(cardImage.waitForExistence(timeout: 2))
-    
-    let cardName = app.staticTexts.containing(
-        NSPredicate(format: "label CONTAINS[c] 'The'")
-    ).firstMatch
-    XCTAssertTrue(cardName.exists)
-}
-```
+- Artwork download scripts reference the Rider–Waite–Smith deck hosted by the Sacred Texts Archive. The images are in the public domain; review local laws before redistribution.【F:scripts/download_rws_cards.sh†L1-L92】
+- No explicit open-source license file is currently included. Please contact the maintainer before reusing the code or assets commercially.
 
 ---
 
-## 🎯 Development Highlights for Hiring Managers
-
-### Problems Solved
-
-#### 1. **Offline Reliability on Resource-Constrained Devices**
-- **Challenge:** Watch apps have limited storage and intermittent connectivity
-- **Solution:** Implemented intelligent storage monitoring with automatic pruning
-- **Impact:** App maintains <20MB footprint while storing 100+ history entries
-- **Metrics:** 0 storage-related crashes in testing, 80% threshold warning system
-
-#### 2. **True Randomness for Fair User Experience**
-- **Challenge:** Standard `random()` can be predictable and non-uniform
-- **Solution:** Cryptographic RNG with statistical validation tests
-- **Implementation:** `SystemRandomNumberGenerator` + Fisher-Yates shuffle
-- **Validation:** Chi-square test confirms uniform distribution (p > 0.05)
-
-#### 3. **High Test Coverage Despite UI-Heavy Application**
-- **Challenge:** SwiftUI views difficult to unit test traditionally
-- **Solution:** MVVM with protocol injection + ViewInspector for view testing
-- **Achievement:** 85% overall coverage (industry standard: 60-70%)
-- **Benefit:** Regression prevention, easier refactoring, production confidence
-
-#### 4. **Production-Ready CI/CD for One-Person Project**
-- **Challenge:** Maintain code quality without team code reviews
-- **Solution:** Automated linting, formatting, testing, coverage enforcement
-- **Tools:** GitHub Actions, SwiftLint (strict), SwiftFormat, pre-commit hooks
-- **Result:** Consistent code style, enforced best practices, deployment confidence
-
----
-
-## 🔄 Development Workflow
-
-### Git Commit Convention
-```
-feat: add cryptographic randomization to card draws
-fix: resolve storage warning alert dismissal bug
-test: add comprehensive HistoryViewModel test suite
-docs: update README with architecture diagrams
-refactor: extract card selection logic to utility
-perf: optimize image loading with lazy instantiation
-```
-
-### Branch Strategy
-```
-main         → Production-ready code, tagged releases
-develop      → Integration branch for features
-feature/*    → Individual feature development
-bugfix/*     → Bug fixes
-hotfix/*     → Production hotfixes
-```
-
-### Pre-commit Checks (Automatic)
-- ✅ SwiftLint validation
-- ✅ SwiftFormat application
-- ✅ Affected unit tests run
-- ✅ Build verification
-
----
-
-## 📈 Future Enhancements
-
-### Planned Features (Post-MVP)
-- [ ] **Multiple Deck Support** — Marseille, Thoth, themed decks via IAP ($1.99 each)
-- [ ] **Reading Interpretations** — Extended upright/reversed meanings ($2.99 IAP)
-- [ ] **Daily Reading Widget** — Watch face complication with Card of the Day
-- [ ] **Reading Journal** — Notes and reflections on each pull
-- [ ] **iCloud Sync** — History sync across iPhone companion app
-- [ ] **Spread Support** — 3-card, Celtic Cross layouts
-- [ ] **Localization** — Spanish, French, German translations
-
-### Technical Debt & Improvements
-- [ ] Migrate to Swift 6.0 strict concurrency when stable
-- [ ] Add snapshot testing for UI regression prevention
-- [ ] Implement analytics (privacy-preserving, local-only)
-- [ ] Create companion iPhone app for detailed readings
-
----
-
-## 📄 License & Attribution
-
-### License
-This project is licensed under the **MIT License** — see [LICENSE](LICENSE) file for details.
-
-### Image Attribution
-Card images sourced from **Sacred Texts Archive** (public domain, pre-1923):
-- Rider-Waite-Smith Tarot Deck
-- Original scans: https://sacred-texts.com/tarot/pkt/
-
-All images are in the **public domain** in the United States and most other countries due to:
-- Published before 1923 (pre-copyright extension)
-- No copyright renewal filed
-- US government publication status
-
-See [ATTRIBUTIONS.md](ATTRIBUTIONS.md) for detailed image provenance.
-
----
-
-## 👨‍💻 About the Developer
-
-**Geoff Gallinger**  
-Junior Software Engineer → Senior Engineer Aspirant
-
-This project demonstrates:
-- ✅ Production-grade Swift/SwiftUI development
-- ✅ Test-driven development methodology
-- ✅ CI/CD pipeline architecture
-- ✅ Protocol-oriented programming
-- ✅ Performance optimization for constrained devices
-- ✅ User experience design for small form factors
-- ✅ Solo project management from ideation to deployment
-
-**Connect:**
-- 🌐 Blog: [An Agentic Development](https://blog.aptitude.guru)
-- 💼 LinkedIn: [linkedin.com/in/geoff-gallinger](https://linkedin.com/in/geoff-gallinger)
-- 🐙 GitHub: [@Geoffe-Ga](https://github.com/Geoffe-Ga)
-- 📧 Email: geoffe.gallinger@gmail.com
-
----
-
-## 🙏 Acknowledgments
-
-- **Pamela Colman Smith** — Visionary artist of the Rider-Waite tarot deck
-- **Arthur Edward Waite** — Deck designer and mystic scholar
-- **Sacred Texts Archive** — Preserving public domain spiritual texts
-- **Apple Developer Community** — SwiftUI and watchOS guidance
-
----
-
-<p align="center">
-  <strong>Built with ❤️ and ☕ for Apple Watch</strong><br>
-  <sub>Demonstrating senior-level iOS engineering practices</sub>
-</p>
-
----
-
-## 📞 Contact & Collaboration
-
-**For Hiring Managers:**  
-I'm actively seeking **mid-level Software Engineer positions**. This project showcases:
-- Production app architecture and design patterns
-- Comprehensive testing and quality assurance
-- CI/CD and DevOps practices
-- Solo ownership of full development lifecycle
-
-**For AI Collaborators:**  
-This README provides complete context for understanding the codebase architecture, testing strategy, and development workflow. See the [CONTRIBUTING.md](CONTRIBUTING.md) for detailed coding standards and PR guidelines.
-
-**For Open Source Contributors:**  
-Contributions welcome! Please see [CONTRIBUTING.md](CONTRIBUTING.md) for:
-- Code style guidelines
-- Testing requirements
-- PR process
-- Community standards
+Questions or ideas? Open an issue or reach out via the contact details in the project history.


### PR DESCRIPTION
## Summary
- rewrite the README to describe the current watchOS app features and architecture
- document the existing scripts, testing approach, and repository layout
- call out the lack of a published license and update setup instructions for watchOS 11

## Testing
- not run (docs only)


------
https://chatgpt.com/codex/tasks/task_e_68e44b766c788322a85cd54e069e1668