### PR TITLE
fix: add fallback card to TarotDeck.riderWaite static property (BUG-003)

### DIFF
--- a/WristArcana/Models/TarotDeck.swift
+++ b/WristArcana/Models/TarotDeck.swift
@@ -22,12 +22,23 @@ struct TarotDeck: Codable, Identifiable, Equatable {
         self.cards = cards
     }
 
-    // Static helper for Rider-Waite deck
+    // Static helper for Rider-Waite deck with fallback card
+    // Used as last-resort fallback when repository fails to load decks
     static var riderWaite: TarotDeck {
         TarotDeck(
-            id: UUID().uuidString,
+            id: "rider-waite-fallback",
             name: "Rider-Waite",
-            cards: []
+            cards: [
+                TarotCard(
+                    name: "The Fool",
+                    imageName: "major_00",
+                    suit: .majorArcana,
+                    number: 0,
+                    upright: "New beginnings, optimism, trust in life. The universe is ready to support your journey.",
+                    reversed: "Recklessness, taken advantage of, inconsideration. Pause before leaping.",
+                    keywords: ["beginnings", "innocence", "spontaneity", "free spirit"]
+                )
+            ]
         )
     }
 }

--- a/WristArcana/WristArcana Watch AppTests/ModelTests/TarotDeckTests.swift
+++ b/WristArcana/WristArcana Watch AppTests/ModelTests/TarotDeckTests.swift
@@ -137,4 +137,34 @@ struct TarotDeckTests {
         // Then
         #expect(deck1 == deck2)
     }
+
+    // MARK: - Static Properties Tests
+
+    @Test func riderWaite_hasAtLeastOneCard() async throws {
+        // When
+        let deck = TarotDeck.riderWaite
+
+        // Then - Must have at least 1 card to prevent crashes in getRandomCard
+        #expect(deck.cards.count >= 1, "TarotDeck.riderWaite must have at least 1 card to prevent crashes")
+    }
+
+    @Test func riderWaite_neverReturnsEmptyDeck() async throws {
+        // When
+        let deck = TarotDeck.riderWaite
+
+        // Then - Used as fallback, so must never be empty
+        #expect(!deck.cards.isEmpty, "TarotDeck.riderWaite is used as fallback and must never be empty")
+    }
+
+    @Test func riderWaite_hasValidCardData() async throws {
+        // When
+        let deck = TarotDeck.riderWaite
+
+        // Then - First card should have valid data
+        let firstCard = deck.cards.first!
+        #expect(!firstCard.name.isEmpty, "Card must have a name")
+        #expect(!firstCard.imageName.isEmpty, "Card must have an image name")
+        #expect(!firstCard.upright.isEmpty, "Card must have upright meaning")
+        #expect(!firstCard.reversed.isEmpty, "Card must have reversed meaning")
+    }
 }


### PR DESCRIPTION
## Summary
- Fixes `TarotDeck.riderWaite` static property which was initialized with zero cards
- Adds The Fool card as a minimal 1-card fallback to prevent crashes when used in `DeckRepository.getCurrentDeck()`
- Implements TDD approach with 3 new tests enforcing deck is never empty

## Changes
- **TarotDeck.swift**: Added The Fool card to `riderWaite` static property
- **TarotDeckTests.swift**: Added 3 tests verifying deck is never empty and has valid data

## Test Results
✅ All unit tests pass (73 tests)
✅ DrawCardViewResponsivenessUITests pass (8 tests - what CI checks)

## Closes
Closes #32

🤖 Generated with [Claude Code](https://claude.com/claude-code)