### PR TITLE
fix: share ModelContainer between app and intents to prevent database conflicts (BUG-005)

### DIFF
--- a/WristArcana/AppIntents/DrawCardIntent.swift
+++ b/WristArcana/AppIntents/DrawCardIntent.swift
@@ -26,9 +26,8 @@ struct DrawCardIntent: AppIntent {
 
     @MainActor
     func perform() async throws -> some IntentResult & ProvidesDialog {
-        // Initialize SwiftData container
-        let container = try ModelContainer(for: CardPull.self)
-        let modelContext = ModelContext(container)
+        // Use shared ModelContainer to prevent database conflicts with main app
+        let modelContext = ModelContext(WristArcanaApp.sharedModelContainer)
 
         // Initialize dependencies
         let repository = DeckRepository()

--- a/WristArcana/WristArcanaApp.swift
+++ b/WristArcana/WristArcanaApp.swift
@@ -3,10 +3,28 @@ import SwiftUI
 
 @main
 struct WristArcanaApp: App {
+    /// Shared ModelContainer used by both the app and App Intents to prevent database conflicts.
+    /// Creating multiple containers can cause SQLite lock issues and data inconsistency.
+    static let sharedModelContainer: ModelContainer = {
+        let schema = Schema([CardPull.self])
+        let configuration = ModelConfiguration(
+            schema: schema,
+            isStoredInMemoryOnly: false,
+            allowsSave: true
+        )
+
+        do {
+            return try ModelContainer(for: schema, configurations: [configuration])
+        } catch {
+            // If container creation fails, this is a critical error
+            fatalError("Failed to create shared ModelContainer: \(error)")
+        }
+    }()
+
     var body: some Scene {
         WindowGroup {
             ContentView()
         }
-        .modelContainer(for: [CardPull.self])
+        .modelContainer(Self.sharedModelContainer)
     }
 }


### PR DESCRIPTION
## Summary
- Fixes duplicate ModelContainer creation that causes database lock conflicts
- Makes ModelContainer a shared static property used by both app and App Intents
- Prevents SQLite conflicts when Siri shortcuts run while app is backgrounded

## Changes
- **WristArcanaApp.swift**: Created `sharedModelContainer` as static property
- **DrawCardIntent.swift**: Updated to use shared container instead of creating its own

## Why This Fix Works
Creating multiple ModelContainers pointing to the same database causes:
- SQLite lock conflicts (multiple connections to same file)
- Data inconsistency between app and intent
- Potential app hangs or crashes when both try to save simultaneously

By sharing a single container:
- All database access uses the same connection
- SwiftData can properly coordinate writes
- No lock conflicts between app and shortcuts

## Test Results
✅ All unit tests pass (75 tests)
✅ DrawCardViewResponsivenessUITests pass (8 tests - what CI checks)

## Closes
Closes #34

🤖 Generated with [Claude Code](https://claude.com/claude-code)