### PR TITLE
refactor: replace try! with proper error handling in test setup (BUG-011)

### DIFF
--- a/WristArcana/WristArcana Watch AppTests/ViewModelTests/CardDrawViewModelTests.swift
+++ b/WristArcana/WristArcana Watch AppTests/ViewModelTests/CardDrawViewModelTests.swift
@@ -17,8 +17,12 @@ struct CardDrawViewModelTests {
     func createInMemoryModelContainer() -> ModelContainer {
         let schema = Schema([CardPull.self])
         let configuration = ModelConfiguration(isStoredInMemoryOnly: true)
-        // swiftlint:disable:next force_try
-        return try! ModelContainer(for: schema, configurations: [configuration])
+
+        do {
+            return try ModelContainer(for: schema, configurations: [configuration])
+        } catch {
+            fatalError("Failed to create in-memory ModelContainer for tests: \(error.localizedDescription)")
+        }
     }
 
     func createSUT(

--- a/WristArcana/WristArcana Watch AppTests/ViewModelTests/DrawCardViewAddNoteHandlerTests.swift
+++ b/WristArcana/WristArcana Watch AppTests/ViewModelTests/DrawCardViewAddNoteHandlerTests.swift
@@ -17,8 +17,12 @@ struct DrawCardViewAddNoteHandlerTests {
     func createInMemoryModelContainer() -> ModelContainer {
         let schema = Schema([CardPull.self])
         let configuration = ModelConfiguration(isStoredInMemoryOnly: true)
-        // swiftlint:disable:next force_try
-        return try! ModelContainer(for: schema, configurations: [configuration])
+
+        do {
+            return try ModelContainer(for: schema, configurations: [configuration])
+        } catch {
+            fatalError("Failed to create in-memory ModelContainer for tests: \(error.localizedDescription)")
+        }
     }
 
     func createSamplePull(note: String? = nil) -> CardPull {

--- a/WristArcana/WristArcana Watch AppTests/ViewModelTests/HistoryViewModelTests.swift
+++ b/WristArcana/WristArcana Watch AppTests/ViewModelTests/HistoryViewModelTests.swift
@@ -17,8 +17,12 @@ struct HistoryViewModelTests {
     func createInMemoryModelContainer() -> ModelContainer {
         let schema = Schema([CardPull.self])
         let configuration = ModelConfiguration(isStoredInMemoryOnly: true)
-        // swiftlint:disable:next force_try
-        return try! ModelContainer(for: schema, configurations: [configuration])
+
+        do {
+            return try ModelContainer(for: schema, configurations: [configuration])
+        } catch {
+            fatalError("Failed to create in-memory ModelContainer for tests: \(error.localizedDescription)")
+        }
     }
 
     func createSamplePull(


### PR DESCRIPTION
## Summary
Replaces force-try (`try!`) operators with descriptive error handling in test helper methods for better debugging.

### Changes
Affected files:
- `HistoryViewModelTests.swift`
- `CardDrawViewModelTests.swift`
- `DrawCardViewAddNoteHandlerTests.swift`

**Before:**
```swift
func createInMemoryModelContainer() -> ModelContainer {
    // swiftlint:disable:next force_try
    return try! ModelContainer(for: schema, configurations: [configuration])
}
```

**After:**
```swift
func createInMemoryModelContainer() -> ModelContainer {
    do {
        return try ModelContainer(for: schema, configurations: [configuration])
    } catch {
        fatalError("Failed to create in-memory ModelContainer for tests: \(error.localizedDescription)")
    }
}
```

### Benefits
- **Better debugging**: Tests fail with descriptive error messages instead of cryptic crashes
- **Cleaner code**: Removed 3 `swiftlint:disable:next force_try` comments
- **Best practices**: Follows Swift guidelines for test code error handling
- **No behavior change**: Still fails tests on error, just with better diagnostics

### Test Results
✅ All 82 unit tests pass  
✅ SwiftLint/SwiftFormat compliance  
✅ No functionality changed

### Related Issues
Fixes #40 (BUG-011: Fragile test assertions using try! instead of proper error handling)

🤖 Generated with [Claude Code](https://claude.com/claude-code)