### PR TITLE
fix: replace nested sheet with fullScreenCover to prevent watchOS navigation issues

### DIFF
--- a/WristArcana/Views/DrawCardView.swift
+++ b/WristArcana/Views/DrawCardView.swift
@@ -111,32 +111,34 @@ struct DrawCardView: View {
                     card: card,
                     onDismiss: dismissCard,
                     onShowDetail: {
+                        // Dismiss preview first, then show detail
+                        self.showingPreview = false
                         self.showingDetail = true
                     }
                 )
-                .sheet(isPresented: self.$showingDetail) {
-                    CardDisplayView(
-                        card: card,
-                        cardPull: self.viewModel?.currentCardPull,
-                        onAddNote: makeAddNoteHandler(
-                            stageNote: { pull in
-                                self.pendingNotePull = pull
-                            },
-                            dismissCard: {
-                                // Dismiss BOTH sheets
-                                self.showingDetail = false
-                                self.showingPreview = false
-                                self.viewModel?.dismissCard()
-                            }
-                        ),
-                        onDismiss: {
-                            // Dismiss BOTH sheets, return directly to DrawCardView
+            }
+        }
+        .fullScreenCover(isPresented: self.$showingDetail) {
+            if let card = viewModel?.currentCard, let viewModel = self.viewModel {
+                CardDisplayView(
+                    card: card,
+                    cardPull: viewModel.currentCardPull,
+                    onAddNote: makeAddNoteHandler(
+                        stageNote: { pull in
+                            self.pendingNotePull = pull
+                        },
+                        dismissCard: {
+                            // Dismiss detail view only
                             self.showingDetail = false
-                            self.showingPreview = false
                             self.viewModel?.dismissCard()
                         }
-                    )
-                }
+                    ),
+                    onDismiss: {
+                        // Dismiss detail view, return directly to DrawCardView
+                        self.showingDetail = false
+                        self.viewModel?.dismissCard()
+                    }
+                )
             }
         }
         .onChange(of: self.showingPreview) { _, isShowing in


### PR DESCRIPTION
## Summary
Fixes #36 (BUG-007: Nested sheet presentation on watchOS causes navigation issues)

**Problem:**
- DrawCardView used nested `.sheet()` modifiers (CardPreviewView containing CardDisplayView)
- watchOS doesn't handle nested sheets well, causing state corruption and unresponsive UI
- Detail view dismiss could affect preview sheet state

**Solution:**
- Replaced nested `.sheet()` with separate `.fullScreenCover()` for detail view
- Preview sheet dismisses first, then detail view shows as fullScreenCover
- Each presentation is independent at the top level
- Detail view can dismiss without affecting preview state

## Changes
- **DrawCardView.swift:**
  - Moved CardDisplayView presentation to separate `.fullScreenCover()` modifier
  - Updated `onShowDetail` in CardPreviewView to dismiss preview before showing detail
  - Updated `onDismiss` handlers to only affect their respective presentations

## Test Plan
- [x] All unit tests pass (174/174)
- [x] SwiftLint validation passes (0 violations)
- [ ] Manual testing: Verify card draw → preview → detail flow works smoothly
- [ ] Manual testing: Verify detail view dismisses cleanly back to DrawCardView
- [ ] Manual testing: Verify note-adding flow from detail view works

🤖 Generated with [Claude Code](https://claude.com/claude-code)