### PR TITLE
fix: add Task cancellation handling to drawCard sleep

### DIFF
--- a/WristArcana/ViewModels/CardDrawViewModel.swift
+++ b/WristArcana/ViewModels/CardDrawViewModel.swift
@@ -53,6 +53,12 @@ final class CardDrawViewModel: ObservableObject {
         // Add minimum 0.5s delay for anticipation/animation
         try? await Task.sleep(nanoseconds: AppConstants.minimumDrawDuration)
 
+        // Check if task was cancelled during sleep (user navigated away)
+        guard !Task.isCancelled else {
+            self.isDrawing = false
+            return
+        }
+
         do {
             let deck = self.repository.getCurrentDeck()
             guard let card = self.selectRandomCard(from: deck) else {

--- a/WristArcana/WristArcana Watch AppTests/ViewModelTests/CardDrawViewModelTests.swift
+++ b/WristArcana/WristArcana Watch AppTests/ViewModelTests/CardDrawViewModelTests.swift
@@ -319,4 +319,25 @@ struct CardDrawViewModelTests {
         #expect(pull.cardImageName == sut.currentCard?.imageName)
         #expect(pull.date.timeIntervalSinceNow < 1) // Recent
     }
+
+    // MARK: - Task Cancellation Tests
+
+    @Test func drawCard_resetsIsDrawingOnTaskCancellation() async throws {
+        // Given
+        let sut = self.createSUT()
+
+        // When - Cancel task during sleep
+        let task = Task {
+            await sut.drawCard()
+        }
+
+        // Cancel during the 0.5s sleep
+        try? await Task.sleep(nanoseconds: 100_000_000) // 0.1s
+        task.cancel()
+        await task.value
+
+        // Then
+        #expect(sut.isDrawing == false, "Should reset isDrawing on cancellation")
+        #expect(sut.currentCard == nil, "Should not set currentCard on cancellation")
+    }
 }


### PR DESCRIPTION
## Summary
Fixes #41 (BUG-012: Task.sleep error handling silently swallows cancellation errors)

**Problem:**
- `Task.sleep` uses `try?` which silently swallows cancellation errors
- If user navigates away during card draw delay (0.5s), execution continues anyway
- Inconsistent UX timing when task is cancelled mid-draw
- Violates error handling best practices (silent failures)

**Solution:**
- Added `Task.isCancelled` check immediately after sleep
- Early return if task was cancelled during delay
- Resets `isDrawing` state before returning
- Prevents continuing execution when user has navigated away

## Changes
- **CardDrawViewModel.swift:**
  - Added `guard !Task.isCancelled` after `Task.sleep`
  - Sets `isDrawing = false` if cancelled
  - Returns early to prevent incomplete state

## Test Plan
- [x] All unit tests pass (178/178)
- [x] Existing tests verify normal card draw flow works
- [ ] Manual testing: Start draw, immediately navigate away
- [ ] Manual testing: Verify task cancels gracefully without state corruption

🤖 Generated with [Claude Code](https://claude.com/claude-code)