### PR TITLE
fix: replace onAppear with task to prevent ViewModel race conditions (BUG-008)

### DIFF
--- a/WristArcana/Views/DrawCardView.swift
+++ b/WristArcana/Views/DrawCardView.swift
@@ -192,7 +192,7 @@ struct DrawCardView: View {
                 Text(error)
             }
         }
-        .onAppear {
+        .task {
             if self.viewModel == nil {
                 self.viewModel = CardDrawViewModel(
                     repository: self.repository,

--- a/WristArcana/Views/HistoryView.swift
+++ b/WristArcana/Views/HistoryView.swift
@@ -40,7 +40,7 @@ struct HistoryView: View {
             }
             .navigationTitle("History")
         }
-        .onAppear {
+        .task {
             if self.viewModel == nil {
                 self.viewModel = HistoryViewModel(
                     modelContext: self.modelContext,


### PR DESCRIPTION
## Summary
- Replace `.onAppear` with `.task` in DrawCardView for ViewModel initialization
- Replace `.onAppear` with `.task` in HistoryView for ViewModel initialization

## Problem
ViewModels initialized in `.onAppear` can be called multiple times due to:
- Tab switching
- Background/foreground transitions
- View redraws

This can cause subtle race conditions and state inconsistencies, especially with SwiftData ModelContext.

## Solution
Use `.task` instead of `.onAppear` because:
- Automatically cancels when view disappears
- Won't run multiple times for the same view instance
- Better lifecycle management for async initialization
- Prevents duplicate ModelContext instances

## Testing
✅ All existing unit tests pass (no changes required)
✅ ViewModels still initialize correctly
✅ No regression in functionality

## Closes
Closes #37

🤖 Generated with [Claude Code](https://claude.com/claude-code)