### PR TITLE
fix: Add Note button now shows note editor instead of dismissing

### DIFF
--- a/WristArcana/Views/DrawCardView.swift
+++ b/WristArcana/Views/DrawCardView.swift
@@ -141,8 +141,9 @@ struct DrawCardView: View {
                 )
             }
         }
-        .onChange(of: self.showingPreview) { _, isShowing in
-            guard !isShowing, !self.showingDetail,
+        .onChange(of: self.showingDetail) { _, isShowing in
+            // When detail view is dismissed and there's a pending note, show the note editor
+            guard !isShowing,
                   let histViewModel = self.historyViewModel,
                   let pull = drainPendingNotePull(&self.pendingNotePull)
             else {


### PR DESCRIPTION
## Summary

Fixes the "Add Note" button on the card detail screen which was dismissing the view instead of showing the note editor.

**Root Cause:** The `onChange` handler in `DrawCardView.swift` was watching `showingPreview` instead of `showingDetail`. When the user tapped "Add Note" from the detail view:
- `showingDetail` changed from `true` → `false`
- `showingPreview` was already `false` (dismissed when detail opened)
- The `onChange` never fired because `showingPreview` didn't change

**Fix:** Changed `onChange(of: self.showingPreview)` to `onChange(of: self.showingDetail)` so the handler correctly triggers when the detail view is dismissed with a pending note.

## Changes

- `WristArcana/Views/DrawCardView.swift`: Fixed onChange to watch correct state variable

## Test Plan

- [x] Unit tests pass (59% coverage)
- [x] SwiftLint passes
- [x] SwiftFormat passes
- [x] Pre-commit hooks pass
- [ ] **MANUAL TESTING REQUIRED** before merge:
  - [ ] Draw card → Detail → Add Note → Editor appears
  - [ ] Type note → Save → Note visible in detail view
  - [ ] Edit existing note → Changes persist
  - [ ] Cancel editing → Note unchanged
  - [ ] Test on multiple watch sizes (41mm, 45mm, Ultra)

## ⚠️ DO NOT MERGE until manual testing is confirmed

This PR requires manual testing on a real device or simulator before merging. The note-taking flow involves keyboard presentation and SwiftUI sheet interactions that need visual verification.

Closes #59

🤖 Generated with [Claude Code](https://claude.com/claude-code)