### PR TITLE
fix: restore iOS stub container target required for App Store distribution

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,6 +48,35 @@ jobs:
             -destination 'platform=watchOS Simulator,name=Apple Watch Series 10 (46mm)' \
             CODE_SIGNING_ALLOWED=NO
 
+  # Guards against the iOS stub container target being removed again.
+  # Watch-only apps must ship inside a watchapp2-container for App Store
+  # distribution; removing it (cc65a6b, Nov 2025) silently broke uploads
+  # until the next submission attempt. This archives the container scheme
+  # unsigned and verifies the watch app is embedded — no export, no upload.
+  archive-guard:
+    runs-on: macos-15
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Select Xcode 16.4
+        run: sudo xcode-select -s /Applications/Xcode_16.4.app/Contents/Developer
+
+      - name: Archive container scheme (no codesign, no upload)
+        env:
+          NSUnbufferedIO: "YES"
+        run: |
+          set -eo pipefail
+          xcodebuild archive \
+            -project WristArcana/WristArcana.xcodeproj \
+            -scheme "WristArcana" \
+            -destination 'generic/platform=iOS' \
+            -archivePath /tmp/WristArcana-guard.xcarchive \
+            CODE_SIGNING_ALLOWED=NO
+
+      - name: Verify watch app is embedded in container archive
+        run: |
+          test -d "/tmp/WristArcana-guard.xcarchive/Products/Applications/WristArcana.app/Watch/WristArcana Watch App.app"
+
   test:
     runs-on: macos-15
     steps:

--- a/.swiftformat
+++ b/.swiftformat
@@ -12,7 +12,13 @@
 --trimwhitespace always
 --exclude WristArcana/build,build,DerivedData,Pods,WristArcana/Resources
 
-# Rules enabled by default in newer SwiftFormat versions (CI installs latest via brew).
+# Rules enabled by default in newer SwiftFormat versions (CI installs latest via
+# brew, so new default rules start failing CI without any code change — this
+# happened July 2026, breaking the format check on 20 untouched files).
 # Disabled to keep CI deterministic and preserve project conventions:
-# noForceUnwrapInTests conflicts with our rule that force unwrap is OK in tests.
+# - noForceUnwrapInTests: conflicts with our convention that force unwrap is OK in tests (CLAUDE.md)
+# - redundantAsync/redundantThrows: would churn ~290 test declarations written async/throws by convention
+# - docComments: would rewrite // comments to /// across the codebase
+# - hoistTry: stylistic; we prefer try at the call site
+# Each can be re-enabled later in a dedicated formatting PR.
 --disable docComments,hoistTry,noForceUnwrapInTests,redundantAsync,redundantThrows

--- a/.swiftformat
+++ b/.swiftformat
@@ -11,3 +11,8 @@
 --commas inline
 --trimwhitespace always
 --exclude WristArcana/build,build,DerivedData,Pods,WristArcana/Resources
+
+# Rules enabled by default in newer SwiftFormat versions (CI installs latest via brew).
+# Disabled to keep CI deterministic and preserve project conventions:
+# noForceUnwrapInTests conflicts with our rule that force unwrap is OK in tests.
+--disable docComments,hoistTry,noForceUnwrapInTests,redundantAsync,redundantThrows

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -139,10 +139,15 @@ The app follows a strict MVVM architecture where:
 ### Key Architectural Decisions
 
 1. **Watch-Only App Architecture (Critical)**
-   - NO iOS stub target - this is a native watchOS-only app
-   - Modern watchOS apps (watchOS 6+) don't require an iOS container
-   - Project contains only 3 targets: Watch App, Watch AppTests, Watch AppUITests
-   - IMPORTANT: Never add an iOS target - it causes CI failures and is unnecessary
+   - This is a native watchOS-only app: no iOS companion app, no iOS code, no iOS UI
+   - The project contains 4 targets: `WristArcana` (iOS stub container), Watch App, Watch AppTests, Watch AppUITests
+   - IMPORTANT: The `WristArcana` container target (product type `com.apple.product-type.application.watchapp2-container`) is REQUIRED for App Store distribution — DO NOT remove it
+     - Since Xcode 15.1, App Store Connect only accepts watch-only apps wrapped in this stub container; without it, `xcodebuild -exportArchive` fails with the misleading error `expected one {release-testing, enterprise, debugging} but found app-store-connect`
+     - The container has zero source code — only an empty Resources phase and an "Embed Watch Content" phase; it is packaging, not a companion app, and the App Store listing remains watch-only
+     - It was removed once before (commit `cc65a6b`, Nov 2025) to fix a CI simulator issue, which silently broke App Store distribution and was restored in July 2026
+     - The container's bundle ID (`com.creekmasons.WristArcana`) is the app's identity in App Store Connect; the watch app is `com.creekmasons.WristArcana.watchkitapp`
+   - CI safety: CI and tests use the `WristArcana Watch App` scheme (watchOS simulator only) and never build the container; only the `WristArcana` scheme (used for archiving/distribution) builds it
+   - To archive for the App Store: `xcodebuild -project WristArcana/WristArcana.xcodeproj -scheme WristArcana -destination 'generic/platform=iOS' -archivePath build/WristArcana-container.xcarchive -allowProvisioningUpdates archive`, then `xcodebuild -exportArchive` with `ExportOptions.plist` (method `app-store-connect`)
 
 2. **Local Assets Only (Critical)**
    - ALL 78 card images MUST be loaded from local Asset Catalog
@@ -553,6 +558,7 @@ Image(card.imageName)
 5. **Never commit with SwiftLint warnings** - Pre-commit hooks enforce this
 6. **Never use Core Data** - This project uses SwiftData exclusively
 7. **Never expose multi-deck UI in v1.0** - Feature flag is disabled
+8. **Never remove the `WristArcana` iOS stub container target** - It contains no code and is not a companion app, but App Store distribution is impossible without it (see "Watch-Only App Architecture" above). It was removed once in Nov 2025 and silently broke all App Store uploads.
 
 ## Troubleshooting
 

--- a/ExportOptions.plist
+++ b/ExportOptions.plist
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>method</key>
+    <string>app-store-connect</string>
+    <key>teamID</key>
+    <string>4YP4K7RFL9</string>
+    <key>destination</key>
+    <string>upload</string>
+    <key>signingStyle</key>
+    <string>automatic</string>
+</dict>
+</plist>

--- a/WristArcana/WristArcana.xcodeproj/project.pbxproj
+++ b/WristArcana/WristArcana.xcodeproj/project.pbxproj
@@ -715,6 +715,7 @@
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_CFBundleDisplayName = WristArcana;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 18.0;
 				MARKETING_VERSION = 1.0.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.creekmasons.WristArcana;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -733,6 +734,7 @@
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_CFBundleDisplayName = WristArcana;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 18.0;
 				MARKETING_VERSION = 1.0.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.creekmasons.WristArcana;
 				PRODUCT_NAME = "$(TARGET_NAME)";

--- a/WristArcana/WristArcana.xcodeproj/project.pbxproj
+++ b/WristArcana/WristArcana.xcodeproj/project.pbxproj
@@ -41,9 +41,17 @@
 		676E57212E9A4E000F22194 /* NoteEditorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 676E571F2E9A4E000F22194 /* NoteEditorView.swift */; };
 		676E57222E9A4E000F22194 /* HistoryDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 676E57202E9A4E000F22194 /* HistoryDetailView.swift */; };
 		6772B29B2ED4D02A00877DAA /* CardPreviewView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6772B29A2ED4D02A00877DAA /* CardPreviewView.swift */; };
+		676E559F2E8DE4F200F22194 /* WristArcana Watch App.app in Embed Watch Content */ = {isa = PBXBuildFile; fileRef = 676E559E2E8DE4F200F22194 /* WristArcana Watch App.app */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
+		676E55A02E8DE4F200F22194 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 676E55922E8DE4F200F22194 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 676E559D2E8DE4F200F22194;
+			remoteInfo = "WristArcana Watch App";
+		};
 		676E55AE2E8DE4F400F22194 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 676E55922E8DE4F200F22194 /* Project object */;
@@ -60,7 +68,22 @@
 		};
 /* End PBXContainerItemProxy section */
 
+/* Begin PBXCopyFilesBuildPhase section */
+		676E55C42E8DE4F400F22194 /* Embed Watch Content */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "$(CONTENTS_FOLDER_PATH)/Watch";
+			dstSubfolderSpec = 16;
+			files = (
+				676E559F2E8DE4F200F22194 /* WristArcana Watch App.app in Embed Watch Content */,
+			);
+			name = "Embed Watch Content";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXCopyFilesBuildPhase section */
+
 /* Begin PBXFileReference section */
+		676E55982E8DE4F200F22194 /* WristArcana.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = WristArcana.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		676E559E2E8DE4F200F22194 /* WristArcana Watch App.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "WristArcana Watch App.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		676E55A32E8DE4F200F22194 /* WristArcanaApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WristArcanaApp.swift; sourceTree = "<group>"; };
 		676E55A52E8DE4F200F22194 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
@@ -164,6 +187,7 @@
 		676E55992E8DE4F200F22194 /* Products */ = {
 			isa = PBXGroup;
 			children = (
+				676E55982E8DE4F200F22194 /* WristArcana.app */,
 				676E559E2E8DE4F200F22194 /* WristArcana Watch App.app */,
 				676E55AD2E8DE4F400F22194 /* WristArcana Watch AppTests.xctest */,
 				676E55B72E8DE4F400F22194 /* WristArcana Watch AppUITests.xctest */,
@@ -264,6 +288,25 @@
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
+		676E55972E8DE4F200F22194 /* WristArcana */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 676E55C52E8DE4F400F22194 /* Build configuration list for PBXNativeTarget "WristArcana" */;
+			buildPhases = (
+				676E55962E8DE4F200F22194 /* Resources */,
+				676E55C42E8DE4F400F22194 /* Embed Watch Content */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				676E55A12E8DE4F200F22194 /* PBXTargetDependency */,
+			);
+			name = WristArcana;
+			packageProductDependencies = (
+			);
+			productName = WristArcana;
+			productReference = 676E55982E8DE4F200F22194 /* WristArcana.app */;
+			productType = "com.apple.product-type.application.watchapp2-container";
+		};
 		676E559D2E8DE4F200F22194 /* WristArcana Watch App */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = 676E55C12E8DE4F400F22194 /* Build configuration list for PBXNativeTarget "WristArcana Watch App" */;
@@ -342,6 +385,9 @@
 				LastSwiftUpdateCheck = 1640;
 				LastUpgradeCheck = 1640;
 				TargetAttributes = {
+					676E55972E8DE4F200F22194 = {
+						CreatedOnToolsVersion = 16.4;
+					};
 					676E559D2E8DE4F200F22194 = {
 						CreatedOnToolsVersion = 16.4;
 					};
@@ -369,6 +415,7 @@
 			projectDirPath = "";
 			projectRoot = "";
 			targets = (
+				676E55972E8DE4F200F22194 /* WristArcana */,
 				676E559D2E8DE4F200F22194 /* WristArcana Watch App */,
 				676E55AC2E8DE4F400F22194 /* WristArcana Watch AppTests */,
 				676E55B62E8DE4F400F22194 /* WristArcana Watch AppUITests */,
@@ -377,6 +424,13 @@
 /* End PBXProject section */
 
 /* Begin PBXResourcesBuildPhase section */
+		676E55962E8DE4F200F22194 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		676E559C2E8DE4F200F22194 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -459,6 +513,11 @@
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
+		676E55A12E8DE4F200F22194 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 676E559D2E8DE4F200F22194 /* WristArcana Watch App */;
+			targetProxy = 676E55A02E8DE4F200F22194 /* PBXContainerItemProxy */;
+		};
 		676E55AF2E8DE4F400F22194 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = 676E559D2E8DE4F200F22194 /* WristArcana Watch App */;
@@ -647,6 +706,43 @@
 			};
 			name = Release;
 		};
+		676E55C62E8DE4F400F22194 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = 4YP4K7RFL9;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_CFBundleDisplayName = WristArcana;
+				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
+				MARKETING_VERSION = 1.0.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.creekmasons.WristArcana;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		676E55C72E8DE4F400F22194 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = 4YP4K7RFL9;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_CFBundleDisplayName = WristArcana;
+				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
+				MARKETING_VERSION = 1.0.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.creekmasons.WristArcana;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
 		676E55C92E8DE4F400F22194 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -744,6 +840,15 @@
 			buildConfigurations = (
 				676E55C22E8DE4F400F22194 /* Debug */,
 				676E55C32E8DE4F400F22194 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		676E55C52E8DE4F400F22194 /* Build configuration list for PBXNativeTarget "WristArcana" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				676E55C62E8DE4F400F22194 /* Debug */,
+				676E55C72E8DE4F400F22194 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/WristArcana/WristArcana.xcodeproj/xcshareddata/xcschemes/WristArcana.xcscheme
+++ b/WristArcana/WristArcana.xcodeproj/xcshareddata/xcschemes/WristArcana.xcscheme
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1640"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "676E55972E8DE4F200F22194"
+               BuildableName = "WristArcana.app"
+               BlueprintName = "WristArcana"
+               ReferencedContainer = "container:WristArcana.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldAutocreateTestPlan = "YES">
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>


### PR DESCRIPTION
## Summary

App Store uploads have been silently broken since November 2025: `xcodebuild -exportArchive` with method `app-store-connect` failed with the misleading error `expected one {release-testing, enterprise, debugging} but found app-store-connect`.

**Root cause:** commit cc65a6b removed the iOS stub container target to fix a CI simulator issue. But since Xcode 15.1, App Store Connect only accepts watch-only apps wrapped in a stub container (product type `com.apple.product-type.application.watchapp2-container`) — Xcode's own watch-only template creates one. Without it, the archive is a bare watchOS archive and Xcode refuses to offer the App Store distribution method at all.

## Changes

- **Restore the `WristArcana` container target** (grafted from pre-cc65a6b history) with its Embed Watch Content phase and build configs, plus `GENERATE_INFOPLIST_FILE`, launch-screen generation, and version alignment (1.0.0) with the watch app
- **Add a shared `WristArcana` scheme** used *only* for archiving/distribution (its purpose and usage are documented in CLAUDE.md)
- **Add `ExportOptions.plist`** (`app-store-connect` method, `upload` destination, automatic signing)
- **Add an `archive-guard` CI job** that archives the container scheme unsigned and verifies the watch app is embedded, so accidental removal of the container fails in CI instead of at the next App Store submission
- **Update CLAUDE.md** — the old "never add an iOS target" guidance caused this breakage; it now documents why the container is required and how to archive
- **`.swiftformat`**: disable five rules newly enabled by default in latest SwiftFormat (CI installs it unpinned via brew), which were failing the format check on 20 untouched files; `noForceUnwrapInTests` also conflicts with the project convention that force unwraps are OK in tests

Note: the watch app target keeps `SKIP_INSTALL = YES` (required so it's embedded in the container archive rather than installed at the archive root). An earlier local workaround had flipped it to `NO` in the working tree, but that hack was never committed, so this PR's diff intentionally contains no `SKIP_INSTALL` change.

## Why CI won't break this time

The Nov 2025 CI failure happened because the build scheme pulled in the iOS target. CI and all tests use the `WristArcana Watch App` scheme/target against a watchOS simulator, which never builds the container. Only the new `WristArcana` scheme (archive/distribution, and the new archive-guard job) builds it.

## Not a companion app

The container has **zero source code** — an empty Resources phase and an Embed Watch Content phase. The App Store listing remains watch-only.

## Test plan

- [x] Archive succeeds: `xcodebuild -scheme WristArcana -destination 'generic/platform=iOS' archive`
- [x] Export + upload to App Store Connect succeeded (build 1.0.0 (1) uploaded and processing)
- [x] All unit tests pass locally (59.07% coverage, above the 50% gate)
- [x] UI tests: identical results to `main` (3 pre-existing failures in `WristArcanaWatchAppUITests`, the suite CI marks non-blocking per 562d22a; verified against a clean `main` worktree)
- [x] `swiftformat --lint .` passes locally
- [ ] `archive-guard` CI job passes on this PR (its first run)

🤖 Generated with [Claude Code](https://claude.com/claude-code)